### PR TITLE
Some publishing cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,13 +45,15 @@ subprojects
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
 
-    group "com.badlogicgames.gdx"
-    version "2.0.0" + (isReleaseBuild() ? "" : "-SNAPSHOT")
+    version project.getProperty('version') + (isReleaseBuild() ? "" : "-SNAPSHOT")
 
     java {
         withJavadocJar()
         withSourcesJar()
     }
 }
+
+apply plugin: 'eclipse'
+eclipse.project.name = "root"
 
 apply from: rootProject.file('publish.gradle')

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/JniGenSharedLibraryLoader.java
@@ -33,7 +33,10 @@ import java.util.zip.ZipFile;
  * 
  * See {@link AntScriptGenerator}.
  * 
+ * This class is deprecated in favor of SharedLibraryLoader.
+ * 
  * @author mzechner */
+@Deprecated
 public class JniGenSharedLibraryLoader {
 	private static Set<String> loadedLibraries = new HashSet<String>();
 	private String nativesJar;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+group=com.badlogicgames.gdx
+version=2.0.0
 POM_DESCRIPTION=libGDX jnigen library
 POM_NAME=libGDX jnigen library
 POM_URL=https://github.com/libgdx/gdx-jnigen

--- a/publish.gradle
+++ b/publish.gradle
@@ -39,9 +39,13 @@ subprojects
             repositories {
                 maven {
                     url = version.endsWith('SNAPSHOT') ? getSnapshotRepositoryUrl() : getReleaseRepositoryUrl()
-                    credentials {
-                        username = getRepositoryUsername()
-                        password = getRepositoryPassword()
+                    
+                    if (getRepositoryUsername() || getRepositoryPassword())
+                    {
+                        credentials {
+                            username = getRepositoryUsername()
+                            password = getRepositoryPassword()
+                        }
                     }
                 }
             }

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -28,4 +28,4 @@ Correct the properties. Create a gpg key if you have not yet one.
 
 4. update e.g. gdx-jnigen README.md --> search & replace version numbers!
    update/tag git: e.g. v0.7.0
-   update version to e.g. 0.8.0-SNAPSHOT in build.gradle
+   update version to e.g. 0.8.0 in gradle.properties


### PR DESCRIPTION
* Fix eclipse root project name conflict.
* Move group/version to gradle.properties to allow command line overriding. -Pgroup=your.group
* Fixed test build to use current OS as target.
* Only specify maven.credentials when we have a username/password. Prevents error when publishing to local directory.