### PR TITLE
iOS build

### DIFF
--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -31,7 +31,7 @@ public class JnigenExtension {
 	public static final TargetOs Android = TargetOs.Android;
 	public static final TargetOs IOS = TargetOs.IOS;
 	
-	private Project project;
+	final Project project;
 
 	/**
 	 * Gradle Tasks are executed in the main project working directory. Supply
@@ -145,7 +145,10 @@ public class JnigenExtension {
 				jarAndroidNatives.dependsOn(jarAndroidNativesABIs[i]);
 			}
 		} else if(type == IOS) {
+			if(jarIOSNatives == null)
+				jarIOSNatives = project.getTasks().create("jnigenJarNativesIOS", JnigenIOSJarTask.class);
 			
+			jarIOSNatives.add(target, this);
 		}
 		else {
 			if(jarDesktopNatives == null)

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
@@ -1,0 +1,94 @@
+package com.badlogic.gdx.jnigen.gradle;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.badlogic.gdx.jnigen.BuildTarget;
+import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
+
+public class JnigenIOSJarTask extends JnigenJarTask {
+
+	public JnigenIOSJarTask() {
+		super(TargetOs.IOS);
+	}
+	
+	private void generateXML(File robovmXml, String sharedLibName)
+	{
+		try {
+			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+
+			Document doc = docBuilder.newDocument();
+			Element config = doc.createElement("config");
+			doc.appendChild(config);
+			
+			Element libs = doc.createElement("libs");
+			config.appendChild(libs);
+			
+			//Default assumes we only care about one .a
+			Element lib = doc.createElement("lib");
+			lib.setTextContent("libs/" + sharedLibName);
+			libs.appendChild(lib);
+			
+			TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			Transformer transformer = transformerFactory.newTransformer();
+			DOMSource source = new DOMSource(doc);
+			
+			FileOutputStream fos = new FileOutputStream(robovmXml);
+			
+			StreamResult result = new StreamResult(fos);
+			transformer.setOutputProperty("omit-xml-declaration", "yes"); 
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+			transformer.transform(source, result);
+
+			fos.close();
+		} catch (IOException | ParserConfigurationException | TransformerException e) {
+			throw new RuntimeException("Unable to create temporary robovm.xml file");
+		}
+	}
+	
+	public void add(BuildTarget target, JnigenExtension ext, String abi) {
+		String targetFolder = target.getTargetFolder();
+		
+		String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder;
+		from(path, (copySpec) -> {
+			copySpec.include("*.a");
+			copySpec.into("META-INF/robovm/ios/libs");
+		});
+		
+		from(path, (copySpec) -> {
+			copySpec.include("*.a.tvos");
+			copySpec.into("META-INF/robovm/tvos/libs");
+			copySpec.rename(".tvos$", "");
+		});
+		
+		File robovmXml = new File(ext.subProjectDir + ext.jniDir + File.separatorChar + "robovm.xml");
+		if(!robovmXml.exists()) {
+			generateXML(robovmXml, target.getSharedLibFilename(ext.sharedLibName));
+		}
+		
+		from(robovmXml, (copySpec) -> {
+			copySpec.into("META-INF/robovm/ios");
+			copySpec.rename(".*", "robovm.xml");
+		});
+		from(robovmXml, (copySpec) -> {
+			copySpec.into("META-INF/robovm/tvos");
+			copySpec.rename(".*", "robovm.xml");
+		});
+	}
+}

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenJarTask.java
@@ -31,7 +31,7 @@ public class JnigenJarTask extends Jar {
 		setDescription("Assembles a jar archive containing the native libraries.");
 	}
 	
-	public void add(BuildTarget target, JnigenExtension ext) {
+	public final void add(BuildTarget target, JnigenExtension ext) {
 		add(target, ext, null);
 	}
 	

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -223,10 +223,12 @@ public class AntScriptGenerator {
 		template = template.replace("%jniPlatform%", jniPlatform);
 		template = template.replace("%cCompiler%", target.cCompiler);
 		template = template.replace("%cppCompiler%", target.cppCompiler);
+		template = template.replace("%archiver%", target.archiver);
 		template = template.replace("%compilerPrefix%", target.compilerPrefix);
 		template = template.replace("%cFlags%", target.cFlags);
 		template = template.replace("%cppFlags%", target.cppFlags);
 		template = template.replace("%linkerFlags%", target.linkerFlags);
+		template = template.replace("%archiverFlags%", target.archiverFlags);
 		template = template.replace("%libraries%", target.libraries);
 		template = template.replace("%cIncludes%", cIncludes);
 		template = template.replace("%cExcludes%", cExcludes);

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -44,6 +44,8 @@ public class BuildTarget {
 	public String cCompiler = "gcc";
 	/** the compiler to use when compiling c++ files. Usually g++ or clang++, must not be null */
 	public String cppCompiler = "g++";
+	/** the command to use when archiving files. Usually ar, must not be null */
+	public String archiver = "ar";
 	/** prefix for the compiler (g++, gcc), useful for cross compilation, must not be null **/
 	public String compilerPrefix;
 	/** the flags passed to the C compiler, must not be null **/
@@ -52,6 +54,8 @@ public class BuildTarget {
 	public String cppFlags;
 	/** the flags passed to the linker, must not be null **/
 	public String linkerFlags;
+	/** the flags passed to the archiver, must not be null **/
+	public String archiverFlags = "rcs";
 	/** the name of the generated build file for this target, defaults to "build-${target}(64)?.xml", must not be null **/
 	public String buildFileName;
 	/** whether to exclude this build target from the master build file, useful for debugging **/
@@ -215,6 +219,8 @@ public class BuildTarget {
 				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
 				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
 				"-shared -arch x86_64 -mmacosx-version-min=10.7 -stdlib=libc++");
+			mac.cCompiler = "clang";
+			mac.cppCompiler = "clang++";
 			mac.requireMacOSToBuild = true;
 			return mac;
 		}
@@ -229,7 +235,9 @@ public class BuildTarget {
 		if(type == TargetOs.IOS) {
 			// iOS, 386 simulator and armv7a, compiled to fat static lib
 			BuildTarget ios = new BuildTarget(TargetOs.IOS, false, new String[] {"**/*.c"}, new String[0], new String[] {"**/*.cpp"},
-					new String[0], new String[0], "", "-c -Wall -O2", "-c -Wall -O2", "rcs");
+					new String[0], new String[0], "", "-c -Wall -O2", "-c -Wall -O2", "");
+			ios.cCompiler = "clang";
+			ios.cppCompiler = "clang++";
 			ios.requireMacOSToBuild = true;
 			return ios;
 		}

--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template
@@ -9,8 +9,17 @@
 	<property name="libName" value="%libName%"/>
 	<!-- the jni header jniPlatform to use -->
 	<property name="jniPlatform" value="mac"/>
+	<!-- the compiler to use when compiling c files -->
+	<property name="cCompiler" value="%cCompiler%"/>
+	<!-- the compiler to use when compiling c++ files -->
+	<property name="cppCompiler" value="%cppCompiler%"/>
+	<!-- the command to use when archiving files -->
+	<property name="archiver" value="%archiver%"/>
 	<!-- the compilerPrefix for the C & C++ compilers -->
-	<property name="compilerPrefix" value="%compilerPrefix%"/>		
+	<property name="compilerPrefix" value="%compilerPrefix%"/>
+	<!-- the compilerSuffix for the C & C++ compilers -->
+	<property name="compilerSuffix" value="" />
+	
 	<property name="iphoneos-sdk" value="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/"/>
 	<property name="iphonesimulator-sdk" value="/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"/>
 	<property name="tvos-sdk" value="/Applications/Xcode.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS.sdk/"/>
@@ -18,7 +27,7 @@
 	
 	
 	<!-- define gcc compiler, options and files to compile -->
-	<property name="gcc" value="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"/>	
+	<property name="gcc" value="${compilerPrefix}${cCompiler}${compilerSuffix}"/>
 	<property name="gcc-opts" value="%cFlags%"/>
 	<fileset id="gcc-files" dir="./">
 		<exclude name="target/"/>		
@@ -27,7 +36,7 @@
 	</fileset>
 	
 	<!-- define g++ compiler, options and files to compile -->
-	<property name="g++" value="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"/>
+	<property name="g++" value="${compilerPrefix}${cppCompiler}${compilerSuffix}"/>
 	<property name="g++-opts" value="%cppFlags%"/>
 	<fileset id="g++-files" dir="./">
 		<exclude name="target/"/>
@@ -35,9 +44,9 @@
 		%cppExcludes%
 	</fileset>
 
-	<!-- define linker and options -->
-	<property name="linker" value="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar"/>
-	<property name="linker-opts" value="%linkerFlags%"/>
+	<!-- define ar and options -->
+	<property name="ar" value="${compilerPrefix}${archiver}${compilerSuffix}"/>
+	<property name="ar-opts" value="%archiverFlags%"/>
 	<property name="libraries" value="%libraries%"/>
 	
 	<!-- cleans the build directory, removes all object files and shared libs -->
@@ -104,8 +113,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-386" depends="compile-386">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-386" depends="compile-386">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -113,8 +122,8 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.386" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
@@ -156,8 +165,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-x86_64" depends="compile-x86_64">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-x86_64" depends="compile-x86_64">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -165,8 +174,8 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.x86_64" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
@@ -208,8 +217,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-arm" depends="compile-arm">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-arm" depends="compile-arm">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -217,8 +226,8 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.armv7" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
@@ -260,8 +269,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-arm64" depends="compile-arm64">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-arm64" depends="compile-arm64">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -269,8 +278,8 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.arm64" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
@@ -312,8 +321,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-tvos-x86_64" depends="compile-tvos-x86_64">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-tvos-x86_64" depends="compile-tvos-x86_64">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -321,8 +330,8 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.tvos.x86_64" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
@@ -364,8 +373,8 @@
 		</apply>
 	</target>	
 
-	<!-- links the shared library based on the previously compiled object files -->
-	<target name="link-tvos-arm64" depends="compile-tvos-arm64">
+	<!-- archives the shared library based on the previously compiled object files -->
+	<target name="archive-tvos-arm64" depends="compile-tvos-arm64">
 		<fileset dir="${buildDir}" id="objFileSet">
 			<patternset>
 				<include name="**/*.o" />
@@ -373,15 +382,15 @@
 		</fileset>
 		<pathconvert pathsep=" " property="objFiles" refid="objFileSet" />
 		<mkdir dir="${libsDir}" />
-		<exec executable="${linker}" failonerror="true" dir="${buildDir}">
-			<arg line="${linker-opts}" />
+		<exec executable="${ar}" failonerror="true" dir="${buildDir}">
+			<arg line="${ar-opts}" />
 			<arg path="${libsDir}/${libName}.tvos.arm64" />
 			<arg line="${objFiles}"/>
 			<arg line="${libraries}" />
 		</exec>
 	</target>
 
-	<target name="link-fat">
+	<target name="archive-fat">
 		<exec executable="lipo" failonerror="true" dir="${libsDir}">
 			<arg line="-create -output ${libName} ${libName}.386 ${libName}.x86_64 ${libName}.armv7 ${libName}.arm64"/>
 		</exec>
@@ -390,7 +399,7 @@
 		</exec>
 	</target>
 
-	<target name="postcompile" depends="link-386,link-x86_64,link-arm,link-arm64,link-tvos-x86_64,link-tvos-arm64,link-fat">
+	<target name="postcompile" depends="archive-386,archive-x86_64,archive-arm,archive-arm64,archive-tvos-x86_64,archive-tvos-arm64,archive-fat">
 		%postcompile%
 	</target>
 </project>

--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -11,11 +11,13 @@
 	<property name="jniPlatform" value="%jniPlatform%"/>
 	<!-- the compiler to use when compiling c files -->
 	<property name="cCompiler" value="%cCompiler%"/>
-	<!--  the compiler to use when compiling c++ files -->
+	<!-- the compiler to use when compiling c++ files -->
 	<property name="cppCompiler" value="%cppCompiler%"/>
+	<!-- the command to use when archiving files -->
+	<property name="archiver" value="%archiver%"/>
 	<!-- the compilerPrefix for the C & C++ compilers -->
 	<property name="compilerPrefix" value="%compilerPrefix%"/>
-	<!--  the compilerSuffix for the C & C++ compilers -->	
+	<!-- the compilerSuffix for the C & C++ compilers -->
 	<property name="compilerSuffix" value="" />	
 	
 	<!-- define gcc compiler, options and files to compile -->


### PR DESCRIPTION
* Default macOS/iOS to use clang/clang++ instead of gcc/g++.
* Split linker and archiver into two separate commands to allow using linkerFlags for all projects without issue.
* Unhardcode clang path, it should be on path.
* Allow using compilerPrefix for iOS.

Initial JnigenIOSJarTask.
* ${jniDir}/robovm.xml will be used if exists, otherwise will generate an extremely basic version for you.
* All .a and .a.tvos libraries in output ios folder will be included in the jar. (Allows for adding the extra .a for OpenAL in gdx)