### PR TITLE
Use lwjgl3 style classifiers which split platform + arch into their own jars.

### DIFF
--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -53,11 +53,9 @@ public class JnigenExtension {
 	NativeCodeGeneratorConfig nativeCodeGeneratorConfig;
 	ArrayList<BuildTarget> targets = new ArrayList<BuildTarget>();
 	Action<BuildTarget> all = null;
-	
-	JnigenJarTask jarDesktopNatives = null;
+
 	Task jarAndroidNatives = null;
-	JnigenJarTask[] jarAndroidNativesABIs = null;
-	JnigenJarTask jarIOSNatives = null;
+	JnigenJarTask jarDesktopNatives = null;
 
 	@Inject
 	public JnigenExtension(Project project) {
@@ -95,6 +93,13 @@ public class JnigenExtension {
 	}
 
 	public void add(TargetOs type, boolean is64Bit, boolean isARM, Action<BuildTarget> container) {
+		String name = type + (isARM ? "ARM" : "") + (is64Bit ? "64" : "");
+		
+		if(get(type, is64Bit, isARM) != null)
+			throw new RuntimeException("Attempt to add duplicate build target " + name);
+		if((type == Android || type == IOS) && (is64Bit || isARM))
+			throw new RuntimeException("Android and iOS must not have is64Bit or isARM.");
+		
 		BuildTarget target = BuildTarget.newDefaultTarget(type, is64Bit, isARM);
 
 		if (all != null)
@@ -106,7 +111,7 @@ public class JnigenExtension {
 
 		Task jnigenTask = project.getTasks().getByName("jnigen");
 		Task jnigenBuildTask = project.getTasks().getByName("jnigenBuild");
-		Task builtTargetTask = project.getTasks().create("jnigenBuild" + type + (isARM ? "ARM" : "") + (is64Bit ? "64" : ""),
+		Task builtTargetTask = project.getTasks().create("jnigenBuild" + name,
 				JnigenBuildTargetTask.class, this, target);
 		builtTargetTask.dependsOn(jnigenTask);
 
@@ -114,8 +119,7 @@ public class JnigenExtension {
 			jnigenBuildTask.dependsOn(builtTargetTask);
 		
 		if(type == Android) {
-			if(jarAndroidNatives == null)
-			{
+			if(jarAndroidNatives == null) {
 				jarAndroidNatives = project.getTasks().create("jnigenJarNativesAndroid");
 				jarAndroidNatives.setGroup("jnigen");
 				jarAndroidNatives.setDescription("Assembles all jar archives containing the native libraries for Android.");
@@ -135,25 +139,57 @@ public class JnigenExtension {
 				abis = tmp.toArray(new String[tmp.size()]);
 			}
 			
-			jarAndroidNativesABIs = new JnigenJarTask[abis.length];
+			JnigenJarTask[] jarAndroidNativesABIs = new JnigenJarTask[abis.length];
 			for(int i = 0; i < abis.length; i++) {
-				jarAndroidNativesABIs[i] = project.getTasks().create("jnigenJarNativesAndroid"+abis[i], JnigenJarTask.class, type);
+				jarAndroidNativesABIs[i] = project.getTasks().create("jnigenJarNativesAndroid"+abis[i], JnigenJarTask.class);
 				jarAndroidNativesABIs[i].add(target, this, abis[i]);
 				
 				jarAndroidNatives.dependsOn(jarAndroidNativesABIs[i]);
 			}
 		} else if(type == IOS) {
-			if(jarIOSNatives == null)
-				jarIOSNatives = project.getTasks().create("jnigenJarNativesIOS", JnigenIOSJarTask.class);
-			
+			JnigenIOSJarTask jarIOSNatives = project.getTasks().create("jnigenJarNativesIOS", JnigenIOSJarTask.class);
 			jarIOSNatives.add(target, this);
 		}
 		else {
+			//Desktop jar is for convenience and testing in gradle.
 			if(jarDesktopNatives == null)
-				jarDesktopNatives = project.getTasks().create("jnigenJarNativesDesktop", JnigenJarTask.class, type);
-			
+				jarDesktopNatives = project.getTasks().create("jnigenJarNativesDesktop", JnigenJarTask.class);
 			jarDesktopNatives.add(target, this);
+			
+			JnigenJarTask jarNatives = project.getTasks().create("jnigenJarNatives" + name, JnigenJarTask.class);
+			jarNatives.add(target, this);
 		}
+	}
+	
+	public BuildTarget get(TargetOs type) {
+		return get(type, false, false, null);
+	}
+
+	public BuildTarget get(TargetOs type, boolean is64Bit) {
+		return get(type, is64Bit, false, null);
+	}
+
+	public BuildTarget get(TargetOs type, boolean is64Bit, boolean isARM) {
+		return get(type, is64Bit, isARM, null);
+	}
+
+	public BuildTarget get(TargetOs type, Action<BuildTarget> container) {
+		return get(type, false, false, container);
+	}
+
+	public BuildTarget get(TargetOs type, boolean is64Bit, Action<BuildTarget> container) {
+		return get(type, is64Bit, false, container);
+	}
+
+	public BuildTarget get(TargetOs type, boolean is64Bit, boolean isARM, Action<BuildTarget> container) {
+		for(BuildTarget target : targets) {
+			if(target.os == type && target.is64Bit == is64Bit && target.isARM == isARM) {
+				if(container != null)
+					container.execute(target);
+				return target;
+			}
+		}
+		return null;
 	}
 
 	class NativeCodeGeneratorConfig {

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
@@ -18,12 +18,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import com.badlogic.gdx.jnigen.BuildTarget;
-import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
 
 public class JnigenIOSJarTask extends JnigenJarTask {
 
 	public JnigenIOSJarTask() {
-		super(TargetOs.IOS);
+		super();
+		getArchiveClassifier().set("natives-ios");
 	}
 	
 	private void generateXML(File robovmXml, String sharedLibName)

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenJarTask.java
@@ -14,19 +14,7 @@ import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
  */
 public class JnigenJarTask extends Jar {
 	@Inject
-	public JnigenJarTask(TargetOs os) {
-		switch(os) {
-			case Android:
-				getArchiveClassifier().set("natives-android");
-				break;
-			case IOS:
-				getArchiveClassifier().set("natives-ios");
-				break;
-			default:
-				getArchiveClassifier().set("natives-desktop");
-				break;
-		}
-
+	public JnigenJarTask() {
 		setGroup("jnigen");
 		setDescription("Assembles a jar archive containing the native libraries.");
 	}
@@ -41,6 +29,16 @@ public class JnigenJarTask extends Jar {
 		if (abi != null && !abi.isEmpty()) {
 			targetFolder = abi;
 			getArchiveClassifier().set("natives-" + abi);
+		} else {
+			//We are copying LWJGL3's classifier names, including omitting "-x64"
+			String os = target.os == TargetOs.MacOsX ? "macos" : target.os.name().toLowerCase();
+			if(target.isARM) {
+				os += "-" + (target.is64Bit ? "arm64" : "arm32");
+			} else if(!target.is64Bit) {
+				os += "-x86";
+			}
+
+			getArchiveClassifier().set("natives-" + os);
 		}
 		
 		String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder + File.separatorChar + target.getSharedLibFilename(ext.sharedLibName);


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE, AND WOULD REQUIRE LIBGDX PROJECTS TO UPDATE IF WE USE THIS STYLE CLASSIFIERS IN MAIN LIBGDX**

* Allows macOS and others to be built and published entirely independently.
* Added `get` method to get an existing BuildTarget.
* Added explicit duplicate BuildTarget check.

Example project using split publishing: https://github.com/PokeMMO/jnigen-template/blob/92a1bbd17b3b422b8e1f0fe3fbaa8c9ef40f4407/publish.gradle

* Linux builds will run `./gradlew publishMainPublicationToMavenRepository`
* macOS builds will run `./gradlew publishMacosPublicationToMavenRepository`
