### PR TITLE
Fix InnerClasses with new `javac -h` instead of `javah`.

### DIFF
--- a/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
+++ b/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
@@ -3,6 +3,7 @@ package com.badlogic.gdx.jnigen;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.badlogic.gdx.jnigen.JniGenTestClass.TestInner;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 import java.nio.ByteBuffer;
@@ -109,6 +110,12 @@ public class JniGenTest {
     public void testDouble() {
         assertEquals(0.0, JniGenTestClass.testDouble(0.0), 0.001);
         assertEquals(1.0, JniGenTestClass.testDouble(1.0), 0.001);
+    }
+
+    @Test
+    public void testInner() {
+        assertEquals(1, TestInner.testInner(0));
+        assertEquals(2, TestInner.testInner(1));
     }
 
     @Test

--- a/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTestClass.java
+++ b/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTestClass.java
@@ -60,15 +60,10 @@ class JniGenTestClass {
 			return true;
 	*/
 
-    // @off
-	/*JNI
-	#include <stdio.h>
-	 */
-
-//	public static class TestInner {
-//		public native void testInner(int arg); /*
-//			printf("%d\n", arg);
-//		*/
-//	}
+	public static class TestInner {
+		public native static int testInner(int arg); /*
+			return arg + 1;
+		*/
+	}
 
 }


### PR DESCRIPTION
* javah used to output all InnerClasses into one header file.
* javac -h outputs multiple for ever InnerClass.
* Now we will collect all possible headers and use them all.
* Package/Class collisions shouldn't happen, so this should be safe.