### PR TITLE
Allow absolute paths for jnigen outputs

### DIFF
--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
@@ -25,17 +25,9 @@ public class AndroidNdkScriptGenerator {
 	public void generate (BuildConfig config, BuildTarget target) {
 		if (target.os != TargetOs.Android) throw new IllegalArgumentException("target os must be Android");
 
-		// create all the directories for outputing object files, shared libs and natives jar as well as build scripts.
-		if (!config.libsDir.exists()) {
-			if (!config.libsDir.mkdirs())
-				throw new RuntimeException("Couldn't create directory for shared library files in '" + config.libsDir + "'");
-		}
-		if (!config.jniDir.exists()) {
-			if (!config.jniDir.mkdirs())
-				throw new RuntimeException("Couldn't create native code directory '" + config.jniDir + "'");
-		}
+		config.requireOutputDirs();
 
-		ArrayList<FileDescriptor> files = new ArrayList<FileDescriptor>();
+		ArrayList<FileDescriptor> files = new ArrayList<>();
 
 		int idx = 0;
 		String[] includes = new String[target.cIncludes.length + target.cppIncludes.length];

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildConfig.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildConfig.java
@@ -57,4 +57,15 @@ public class BuildConfig {
 		this.libsDir = new FileDescriptor(libsDir);
 		this.jniDir = new FileDescriptor(jniDir);
 	}
+
+	public void requireOutputDirs() {
+		// create all the directories for outputing object files, shared libs and natives jar as well as build scripts.
+		if (!libsDir.exists() && !libsDir.mkdirs()) {
+			throw new RuntimeException("Couldn't create directory for shared library files in '" + libsDir + "'");
+		}
+		if (!jniDir.exists() && !jniDir.mkdirs()) {
+			throw new RuntimeException("Couldn't create native code directory '" + jniDir + "'");
+		}
+	}
+
 }

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -231,10 +231,8 @@ public class NativeCodeGenerator {
 		}
 
 		// generate jni directory if necessary
-		if (!this.jniDir.exists()) {
-			if (!this.jniDir.mkdirs()) {
-				throw new Exception("Couldn't create JNI directory '" + jniDir + "'");
-			}
+		if (!this.jniDir.exists() && !this.jniDir.mkdirs()) {
+			throw new Exception("Couldn't create JNI directory '" + jniDir + "'");
 		}
 
 		// process the source directory, emitting c/c++ files to jniDir
@@ -316,8 +314,7 @@ public class NativeCodeGenerator {
 		buffer.append("#include <" + fileName + ">\n");
 	}
 
-	private void generateCppFile (ArrayList<JavaSegment> javaSegments, List<FileDescriptor> hFiles, FileDescriptor cppFile)
-		throws Exception {
+	private void generateCppFile (ArrayList<JavaSegment> javaSegments, List<FileDescriptor> hFiles, FileDescriptor cppFile) throws Exception {
 		StringBuffer buffer = new StringBuffer();
 		
 		ArrayList<CMethod> cMethods = new ArrayList<>();

--- a/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
+++ b/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
@@ -20,14 +20,14 @@ public class JniGenTest {
         new NativeCodeGenerator().generate(
                 "src/test/java",
                 System.getProperty("java.class.path"),
-                "build/generated/jni",
+                "build/jnigen/source",
                 new String[] { "**/*.java" },
                 null
         );
 
         // generate build scripts
-        BuildConfig buildConfig = new BuildConfig("test", "../../tmp/gdx-jnigen", "../../build/libs", "build/generated/jni");
-        
+        BuildConfig buildConfig = new BuildConfig("test", "build/jnigen/targets", "build/jnigen/libs", "build/jnigen/source");
+
         BuildTarget target;
         if (SharedLibraryLoader.isWindows)
         	target = BuildTarget.newDefaultTarget(BuildTarget.TargetOs.Windows, SharedLibraryLoader.is64Bit);
@@ -41,17 +41,17 @@ public class JniGenTest {
         new AntScriptGenerator().generate(buildConfig, target);
 
         if (SharedLibraryLoader.isMac) {
-            boolean macAntExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build-macosx64.xml", "-v");
+            boolean macAntExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build-macosx64.xml", "-v");
             if (!macAntExecutionStatus) {
                 throw new RuntimeException("Failure to execute mac ant.");
             }
         } else {
-            boolean antExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build.xml", "-v", "compile-natives");
+            boolean antExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build.xml", "-v", "compile-natives");
             if (!antExecutionStatus) {
                 throw new RuntimeException("Failure to execute mac ant.");
             }
         }
-        boolean antExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build.xml", "-v", "compile-natives", "pack-natives");
+        boolean antExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build.xml", "-v", "compile-natives", "pack-natives");
 
 
         // compile and pack natives


### PR DESCRIPTION
Allows for specifying absolute paths to direct jnigen outputs. This can be useful, for example, when routing jnigen outputs to a Gradle project's build directory to facilitate easy cleanup. The Gradle plugin requires additional changes but wanted to get eyes on this.