### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## gdx-jnigen
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Flibgdx%2Fgdx-jnigen&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 [![Build Status](https://libgdx.badlogicgames.com/jenkins/buildStatus/icon?job=gdx-jnigen)](https://libgdx.badlogicgames.com/jenkins/job/gdx-jnigen/)
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1655)](https://user-images.githubusercontent.com/47092464/98453051-fa669980-218f-11eb-910f-d3f0f48185aa.png)
