### PR TITLE
Revert "Allow absolute paths for jnigen outputs"

### DIFF
--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AndroidNdkScriptGenerator.java
@@ -25,9 +25,17 @@ public class AndroidNdkScriptGenerator {
 	public void generate (BuildConfig config, BuildTarget target) {
 		if (target.os != TargetOs.Android) throw new IllegalArgumentException("target os must be Android");
 
-		config.requireOutputDirs();
+		// create all the directories for outputing object files, shared libs and natives jar as well as build scripts.
+		if (!config.libsDir.exists()) {
+			if (!config.libsDir.mkdirs())
+				throw new RuntimeException("Couldn't create directory for shared library files in '" + config.libsDir + "'");
+		}
+		if (!config.jniDir.exists()) {
+			if (!config.jniDir.mkdirs())
+				throw new RuntimeException("Couldn't create native code directory '" + config.jniDir + "'");
+		}
 
-		ArrayList<FileDescriptor> files = new ArrayList<>();
+		ArrayList<FileDescriptor> files = new ArrayList<FileDescriptor>();
 
 		int idx = 0;
 		String[] includes = new String[target.cIncludes.length + target.cppIncludes.length];

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AntScriptGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/AntScriptGenerator.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.jnigen;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 
 import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
@@ -60,28 +59,36 @@ public class AntScriptGenerator {
 	 * @param config the {@link BuildConfig}
 	 * @param targets list of {@link BuildTarget} instances */
 	public void generate (BuildConfig config, BuildTarget... targets) {
-		config.requireOutputDirs();
+		// create all the directories for outputing object files, shared libs and natives jar as well as build scripts.
+		if (!config.libsDir.exists()) {
+			if (!config.libsDir.mkdirs())
+				throw new RuntimeException("Couldn't create directory for shared library files in '" + config.libsDir + "'");
+		}
+		if (!config.jniDir.exists()) {
+			if (!config.jniDir.mkdirs())
+				throw new RuntimeException("Couldn't create native code directory '" + config.jniDir + "'");
+		}
 
 		// copy jni headers
 		copyJniHeaders(config.jniDir.path());
 
 		// copy memcpy_wrap.c, needed if your build platform uses the latest glibc, e.g. Ubuntu 12.10
-		if (!config.jniDir.child("memcpy_wrap.c").exists()) {
-			new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/memcpy_wrap.c", FileType.Classpath)
-					.copyTo(config.jniDir.child("memcpy_wrap.c"));
+		if (config.jniDir.child("memcpy_wrap.c").exists() == false) {
+			new FileDescriptor("com/badlogic/gdx/jnigen/resources/scripts/memcpy_wrap.c", FileType.Classpath).copyTo(config.jniDir
+				.child("memcpy_wrap.c"));
 		}
 
-		ArrayList<String> buildFiles = new ArrayList<>();
-		ArrayList<String> libsDirs = new ArrayList<>();
-		ArrayList<String> sharedLibFiles = new ArrayList<>();
+		ArrayList<String> buildFiles = new ArrayList<String>();
+		ArrayList<String> libsDirs = new ArrayList<String>();
+		ArrayList<String> sharedLibFiles = new ArrayList<String>();
 
 		// generate an Ant build script for each target
 		for (BuildTarget target : targets) {
 			String buildFile = generateBuildTargetTemplate(config, target);
-			FileDescriptor targetLibsDir = getLibsDirectory(config, target);
+			FileDescriptor libsDir = new FileDescriptor(getLibsDirectory(config, target));
 
-			if (!targetLibsDir.exists() && !targetLibsDir.mkdirs()) {
-				throw new RuntimeException("Couldn't create libs directory '" + targetLibsDir + "'");
+			if (!libsDir.exists()) {
+				if (!libsDir.mkdirs()) throw new RuntimeException("Couldn't create libs directory '" + libsDir + "'");
 			}
 
 			String buildFileName = target.getBuildFilename();
@@ -95,11 +102,10 @@ public class AntScriptGenerator {
 				}
 
 				String sharedLibFilename = target.getSharedLibFilename(config.sharedLibName);
-
+				
 				if (target.os != TargetOs.Android && target.os != TargetOs.IOS) {
-
 					sharedLibFiles.add(sharedLibFilename);
-					libsDirs.add(getRelativeLibsDirectoryPath(config, target));
+					libsDirs.add("../" + libsDir.path().replace('\\', '/'));
 				}
 			}
 		}
@@ -125,21 +131,20 @@ public class AntScriptGenerator {
 			}
 		}
 
-		FileDescriptor buildFile = config.jniDir.child("build.xml");
-
 		template = template.replace("%projectName%", config.sharedLibName + "-natives");
 		template = template.replace("<clean/>", clean.toString());
 		template = template.replace("<compile/>", compile.toString());
-		template = template.replace("%packFile%", getRelativePackFilePath(config));
+		template = template.replace("%packFile%", "../" + config.libsDir.path().replace('\\', '/') + "/" + config.sharedLibName
+			+ "-natives.jar");
 		template = template.replace("<pack/>", pack);
 
-		buildFile.writeString(template, false);
-		System.out.println("Wrote master build script '" + buildFile + "'");
+		config.jniDir.child("build.xml").writeString(template, false);
+		System.out.println("Wrote master build script '" + config.jniDir.child("build.xml") + "'");
 	}
 
 	private void copyJniHeaders (String jniDir) {
 		final String pack = "com/badlogic/gdx/jnigen/resources/headers";
-		String[] files = {"classfile_constants.h", "jawt.h", "jdwpTransport.h", "jni.h", "linux/jawt_md.h", "linux/jni_md.h",
+		String files[] = {"classfile_constants.h", "jawt.h", "jdwpTransport.h", "jni.h", "linux/jawt_md.h", "linux/jni_md.h",
 			"mac/jni_md.h", "win32/jawt_md.h", "win32/jni_md.h"};
 
 		for (String file : files) {
@@ -155,38 +160,8 @@ public class AntScriptGenerator {
 		return "";
 	}
 
-	public static FileDescriptor getPackFile (BuildConfig config) {
-		return config.libsDir.child(config.sharedLibName + "-natives.jar");
-	}
-
-	public static String getRelativePackFilePath (BuildConfig config) {
-		Path path1 = config.jniDir.child("build.xml").file.toPath().toAbsolutePath();
-		Path path2 = getPackFile(config).file().toPath().toAbsolutePath();
-		return getRelativePathString(path1, path2);
-	}
-
-	public static FileDescriptor getBuildDirectory (BuildConfig config, BuildTarget target) {
-		return config.buildDir.child(target.getTargetFolder());
-	}
-
-	public static String getRelativeBuildDirectoryPath (BuildConfig config, BuildTarget target) {
-		Path path1 = config.jniDir.file.toPath().toAbsolutePath();
-		Path path2 = getBuildDirectory(config, target).file.toPath().toAbsolutePath();
-		return getRelativePathString(path1, path2);
-	}
-
-	public static FileDescriptor getLibsDirectory (BuildConfig config, BuildTarget target) {
-		return config.libsDir.child(target.getTargetFolder());
-	}
-
-	public static String getRelativeLibsDirectoryPath (BuildConfig config, BuildTarget target) {
-		Path path1 = config.jniDir.file.toPath().toAbsolutePath();
-		Path path2 = getLibsDirectory(config, target).file.toPath().toAbsolutePath();
-		return getRelativePathString(path1, path2);
-	}
-
-	private static String getRelativePathString(Path path1, Path path2) {
-		return path1.relativize(path2).toString().replace("\\", "/");
+	public static String getLibsDirectory (BuildConfig config, BuildTarget target) {
+		return config.libsDir.child(target.getTargetFolder()).path().replace('\\', '/');
 	}
 
 	private String generateBuildTargetTemplate (BuildConfig config, BuildTarget target) {
@@ -242,8 +217,8 @@ public class AntScriptGenerator {
 
 		// replace template vars with proper values
 		template = template.replace("%projectName%", config.sharedLibName + "-" + target.os + "-" + (target.isARM ? "arm" : "") + (target.is64Bit ? "64" : "32"));
-		template = template.replace("%buildDir%", getRelativeBuildDirectoryPath(config, target));
-		template = template.replace("%libsDir%", getRelativeLibsDirectoryPath(config, target));
+		template = template.replace("%buildDir%", config.buildDir.child(target.getTargetFolder()).path().replace('\\', '/'));
+		template = template.replace("%libsDir%", "../" + getLibsDirectory(config, target));
 		template = template.replace("%libName%", libName);
 		template = template.replace("%jniPlatform%", jniPlatform);
 		template = template.replace("%cCompiler%", target.cCompiler);

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildConfig.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildConfig.java
@@ -57,15 +57,4 @@ public class BuildConfig {
 		this.libsDir = new FileDescriptor(libsDir);
 		this.jniDir = new FileDescriptor(jniDir);
 	}
-
-	public void requireOutputDirs() {
-		// create all the directories for outputing object files, shared libs and natives jar as well as build scripts.
-		if (!libsDir.exists() && !libsDir.mkdirs()) {
-			throw new RuntimeException("Couldn't create directory for shared library files in '" + libsDir + "'");
-		}
-		if (!jniDir.exists() && !jniDir.mkdirs()) {
-			throw new RuntimeException("Couldn't create native code directory '" + jniDir + "'");
-		}
-	}
-
 }

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -231,8 +231,10 @@ public class NativeCodeGenerator {
 		}
 
 		// generate jni directory if necessary
-		if (!this.jniDir.exists() && !this.jniDir.mkdirs()) {
-			throw new Exception("Couldn't create JNI directory '" + jniDir + "'");
+		if (!this.jniDir.exists()) {
+			if (!this.jniDir.mkdirs()) {
+				throw new Exception("Couldn't create JNI directory '" + jniDir + "'");
+			}
 		}
 
 		// process the source directory, emitting c/c++ files to jniDir
@@ -314,7 +316,8 @@ public class NativeCodeGenerator {
 		buffer.append("#include <" + fileName + ">\n");
 	}
 
-	private void generateCppFile (ArrayList<JavaSegment> javaSegments, List<FileDescriptor> hFiles, FileDescriptor cppFile) throws Exception {
+	private void generateCppFile (ArrayList<JavaSegment> javaSegments, List<FileDescriptor> hFiles, FileDescriptor cppFile)
+		throws Exception {
 		StringBuffer buffer = new StringBuffer();
 		
 		ArrayList<CMethod> cMethods = new ArrayList<>();

--- a/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
+++ b/gdx-jnigen/src/test/java/com/badlogic/gdx/jnigen/JniGenTest.java
@@ -20,14 +20,14 @@ public class JniGenTest {
         new NativeCodeGenerator().generate(
                 "src/test/java",
                 System.getProperty("java.class.path"),
-                "build/jnigen/source",
+                "build/generated/jni",
                 new String[] { "**/*.java" },
                 null
         );
 
         // generate build scripts
-        BuildConfig buildConfig = new BuildConfig("test", "build/jnigen/targets", "build/jnigen/libs", "build/jnigen/source");
-
+        BuildConfig buildConfig = new BuildConfig("test", "../../tmp/gdx-jnigen", "../../build/libs", "build/generated/jni");
+        
         BuildTarget target;
         if (SharedLibraryLoader.isWindows)
         	target = BuildTarget.newDefaultTarget(BuildTarget.TargetOs.Windows, SharedLibraryLoader.is64Bit);
@@ -41,17 +41,17 @@ public class JniGenTest {
         new AntScriptGenerator().generate(buildConfig, target);
 
         if (SharedLibraryLoader.isMac) {
-            boolean macAntExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build-macosx64.xml", "-v");
+            boolean macAntExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build-macosx64.xml", "-v");
             if (!macAntExecutionStatus) {
                 throw new RuntimeException("Failure to execute mac ant.");
             }
         } else {
-            boolean antExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build.xml", "-v", "compile-natives");
+            boolean antExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build.xml", "-v", "compile-natives");
             if (!antExecutionStatus) {
                 throw new RuntimeException("Failure to execute mac ant.");
             }
         }
-        boolean antExecutionStatus = BuildExecutor.executeAnt("build/jnigen/source/build.xml", "-v", "compile-natives", "pack-natives");
+        boolean antExecutionStatus = BuildExecutor.executeAnt("build/generated/jni/build.xml", "-v", "compile-natives", "pack-natives");
 
 
         // compile and pack natives


### PR DESCRIPTION
Reverts libgdx/gdx-jnigen#15

Without corresponding changes to the gradle plugin, this appears to have done more harm than good.