### PR TITLE
Use split dylibs for macos.

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -98,7 +98,7 @@ public class SharedLibraryLoader {
 	public String mapLibraryName (String libraryName) {
 		if (isWindows) return libraryName + (is64Bit ? "64.dll" : ".dll");
 		if (isLinux) return "lib" + libraryName + (isARM ? "arm" : "") + (is64Bit ? "64.so" : ".so");
-		if (isMac) return "lib" + libraryName + (is64Bit ? "64.dylib" : ".dylib");
+		if (isMac) return "lib" + libraryName + (isARM ? "arm" : "") + (is64Bit ? "64.dylib" : ".dylib");
 		return libraryName;
 	}
 

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -140,7 +140,7 @@ public class BuildTarget {
 		}
 		if (os == TargetOs.MacOsX) {
 			libPrefix = "lib";
-			libSuffix = (is64Bit ? "64" : "") + ".dylib";
+			libSuffix = (isARM ? "arm" : "") + (is64Bit ? "64" : "") + ".dylib";
 		}
 		if (os == TargetOs.IOS) {
 			libPrefix = "lib";
@@ -216,13 +216,27 @@ public class BuildTarget {
 			throw new RuntimeException("macOS 32-bit not supported");
 		}
 		
-		if (type == TargetOs.MacOsX && is64Bit) {
-			// Mac OS X x86 & x86_64
+		if (type == TargetOs.MacOsX && is64Bit && isARM) {
+			// Mac OS aarch64
 			BuildTarget mac = new BuildTarget(TargetOs.MacOsX, true, new String[] {"**/*.c"}, new String[0],
 				new String[] {"**/*.cpp"}, new String[0], new String[0], "",
-				"-c -Wall -O2 -arch arm64 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-				"-c -Wall -O2 -arch arm64 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-				"-shared -arch arm64 -arch x86_64 -mmacosx-version-min=10.7 -stdlib=libc++");
+				"-c -Wall -O2 -arch arm64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
+				"-c -Wall -O2 -arch arm64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
+				"-shared -arch arm64 -mmacosx-version-min=10.7 -stdlib=libc++");
+			mac.cCompiler = "clang";
+			mac.cppCompiler = "clang++";
+			mac.canBuild = () -> System.getProperty("os.name").contains("Mac");
+			mac.isARM = true;
+			return mac;
+		}
+		
+		if (type == TargetOs.MacOsX && is64Bit) {
+			// Mac OS x86_64
+			BuildTarget mac = new BuildTarget(TargetOs.MacOsX, true, new String[] {"**/*.c"}, new String[0],
+				new String[] {"**/*.cpp"}, new String[0], new String[0], "",
+				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
+				"-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
+				"-shared -arch x86_64 -mmacosx-version-min=10.7 -stdlib=libc++");
 			mac.cCompiler = "clang";
 			mac.cppCompiler = "clang++";
 			mac.canBuild = () -> System.getProperty("os.name").contains("Mac");


### PR DESCRIPTION
* Consistent with how LWJGL3 implemented arm.
* Consistent with other archs.
* Doesn't break backwards compatibility and add arm to existing builds when only x64 was assumed.

Not fully tested, but should be fine™