### PR TITLE
Add basic support for frameworks (iOS).

### DIFF
--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
@@ -67,6 +67,7 @@ public class JnigenIOSJarTask extends JnigenJarTask {
 		
 		String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder;
 		from(path, (copySpec) -> {
+			copySpec.include("**/*.framework/");
 			copySpec.include("*.a");
 			copySpec.into("META-INF/robovm/ios/libs");
 		});
@@ -81,7 +82,7 @@ public class JnigenIOSJarTask extends JnigenJarTask {
 		if(!robovmXml.exists()) {
 			generateXML(robovmXml, target.getSharedLibFilename(ext.sharedLibName));
 		}
-		
+
 		from(robovmXml, (copySpec) -> {
 			copySpec.into("META-INF/robovm/ios");
 			copySpec.rename(".*", "robovm.xml");


### PR DESCRIPTION
This would be currently needed to support gradle builds with MetalANGLE as MetalANGLE currently needs to be packed as a framework.
https://github.com/libgdx/libgdx/pull/6681

(Sorry for the intendation change, git doesn't allowed me to create a commit with only a intendation change to revert my mistake. I hope it is okay!)