### PR TITLE
GenerateRoboVMXml Task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,14 @@ subprojects
         withSourcesJar()
     }
 
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+    }
+
+    tasks.withType(Test) {
+       systemProperty 'file.encoding', 'UTF-8'
+    }
+
     javadoc {
         options.addStringOption('Xdoclint:none', '-quiet')
     }

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -12,11 +12,9 @@ import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.XmlProvider;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.internal.MutableActionSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -260,16 +258,6 @@ public class JnigenExtension {
 	class RoboVMXml {
 		public List<String> forceLinkClasses = new ArrayList<>();
 		public List<RoboVMXmlLib> extraLibs = new ArrayList<>();
-
-		private final MutableActionSet<XmlProvider> xmlAction = new MutableActionSet<>();
-
-		public void withXml(Action<? super XmlProvider> action) {
-			xmlAction.add(action);
-		}
-
-		public Action<XmlProvider> getXmlAction() {
-			return xmlAction;
-		}
 
 		public void forceLinkClass(String forceLinkClass) {
 			forceLinkClasses.add(forceLinkClass);

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateRoboVMXml.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateRoboVMXml.java
@@ -1,0 +1,124 @@
+package com.badlogic.gdx.jnigen.gradle;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+
+import javax.inject.Inject;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.internal.xml.XmlTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import com.badlogic.gdx.jnigen.BuildTarget;
+import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
+import com.badlogic.gdx.jnigen.gradle.JnigenExtension.RoboVMXml.RoboVMXmlLib;
+
+/**
+ * @author Desu
+ */
+public class JnigenGenerateRoboVMXml extends DefaultTask {
+	private static final Logger log = LoggerFactory.getLogger(JnigenGenerateRoboVMXml.class);
+
+	JnigenExtension ext;
+	private final XmlTransformer xmlTransformer = new XmlTransformer();
+
+	@Inject
+	public JnigenGenerateRoboVMXml(JnigenExtension ext) {
+		this.ext = ext;
+
+		setGroup("jnigen");
+		setDescription("Generates robovm.xml file");
+	}
+
+	@TaskAction
+	public void run() {
+		BuildTarget target = ext.get(TargetOs.IOS);
+		if (target == null) {
+			log.info("Nothing to do because no IOS BuildTarget");
+			return;
+		}
+		
+		File oldRobovmXml = new File(ext.subProjectDir + ext.jniDir + File.separatorChar + "robovm.xml");
+		if(oldRobovmXml.exists()) {
+			throw new RuntimeException("Legacy " + oldRobovmXml.getPath() + " file exists, please migrate to gradle declaration and delete this file.");
+		}
+
+		File buildDir = getProject().getBuildDir();
+		if(!buildDir.exists())
+			buildDir.mkdirs();
+		
+		File robovmXml = new File(buildDir, "robovm.xml");
+
+		try {
+			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+
+			Document doc = docBuilder.newDocument();
+			Element config = doc.createElement("config");
+			doc.appendChild(config);
+
+			Element libs = doc.createElement("libs");
+			config.appendChild(libs);
+
+			// Default assumes we only care about one .a
+			Element lib = doc.createElement("lib");
+			lib.setTextContent("libs/" + target.getSharedLibFilename(ext.sharedLibName));
+			libs.appendChild(lib);
+
+			if (!ext.robovm.extraLibs.isEmpty()) {
+				for (RoboVMXmlLib l : ext.robovm.extraLibs) {
+					lib = doc.createElement("lib");
+					if (l.variant != null)
+						lib.setAttribute("variant", l.variant);
+					lib.setTextContent(l.path);
+					libs.appendChild(lib);
+				}
+			}
+
+			if (!ext.robovm.forceLinkClasses.isEmpty()) {
+				Element forceLinkClasses = doc.createElement("forceLinkClasses");
+
+				for (String p : ext.robovm.forceLinkClasses) {
+					Element pattern = doc.createElement("pattern");
+					pattern.setTextContent(p);
+					forceLinkClasses.appendChild(pattern);
+				}
+
+				config.appendChild(forceLinkClasses);
+			}
+
+			TransformerFactory transformerFactory = TransformerFactory.newInstance();
+			Transformer transformer = transformerFactory.newTransformer();
+			DOMSource source = new DOMSource(doc);
+
+			StringWriter writer = new StringWriter();
+			StreamResult result = new StreamResult(writer);
+			transformer.setOutputProperty("omit-xml-declaration", "yes");
+			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+			transformer.transform(source, result);
+
+			FileOutputStream fos = new FileOutputStream(robovmXml);
+			xmlTransformer.addAction(ext.robovm.getXmlAction());
+			xmlTransformer.transform(writer.toString(), fos);
+			fos.close();
+		} catch (IOException | ParserConfigurationException | TransformerException e) {
+			throw new RuntimeException("Unable to create temporary robovm.xml file", e);
+		}
+	}
+}

--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
@@ -1,94 +1,28 @@
 package com.badlogic.gdx.jnigen.gradle;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 import com.badlogic.gdx.jnigen.BuildTarget;
 import com.badlogic.gdx.jnigen.BuildTarget.TargetOs;
 
 public class JnigenIOSJarTask extends JnigenJarTask {
-
 	public JnigenIOSJarTask() {
 		super(TargetOs.IOS);
 	}
-	
-	private void generateXML(File robovmXml, String sharedLibName)
-	{
-		try {
-			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
 
-			Document doc = docBuilder.newDocument();
-			Element config = doc.createElement("config");
-			doc.appendChild(config);
-			
-			Element libs = doc.createElement("libs");
-			config.appendChild(libs);
-			
-			//Default assumes we only care about one .a
-			Element lib = doc.createElement("lib");
-			lib.setTextContent("libs/" + sharedLibName);
-			libs.appendChild(lib);
-			
-			TransformerFactory transformerFactory = TransformerFactory.newInstance();
-			Transformer transformer = transformerFactory.newTransformer();
-			DOMSource source = new DOMSource(doc);
-			
-			FileOutputStream fos = new FileOutputStream(robovmXml);
-			
-			StreamResult result = new StreamResult(fos);
-			transformer.setOutputProperty("omit-xml-declaration", "yes"); 
-			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
-			transformer.transform(source, result);
-
-			fos.close();
-		} catch (IOException | ParserConfigurationException | TransformerException e) {
-			throw new RuntimeException("Unable to create temporary robovm.xml file", e);
-		}
-	}
-	
 	public void add(BuildTarget target, JnigenExtension ext, String abi) {
 		String targetFolder = target.getTargetFolder();
-		
+
 		String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder;
 		from(path, (copySpec) -> {
 			copySpec.include("**/*.framework/");
 			copySpec.include("*.a");
 			copySpec.into("META-INF/robovm/ios/libs");
 		});
-		
-		from(path, (copySpec) -> {
-			copySpec.include("*.a.tvos");
-			copySpec.into("META-INF/robovm/tvos/libs");
-			copySpec.rename(".tvos$", "");
-		});
-		
-		File robovmXml = new File(ext.subProjectDir + ext.jniDir + File.separatorChar + "robovm.xml");
-		if(!robovmXml.exists()) {
-			generateXML(robovmXml, target.getSharedLibFilename(ext.sharedLibName));
-		}
 
+		File robovmXml = new File(getProject().getBuildDir(), "robovm.xml");
 		from(robovmXml, (copySpec) -> {
 			copySpec.into("META-INF/robovm/ios");
-			copySpec.rename(".*", "robovm.xml");
-		});
-		from(robovmXml, (copySpec) -> {
-			copySpec.into("META-INF/robovm/tvos");
 			copySpec.rename(".*", "robovm.xml");
 		});
 	}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
-distributionSha256Sum=038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionSha256Sum=0f316a67b971b7b571dac7215dcf2591a30994b3450e0629925ffcfe2c68cc5c
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Allows customizing the library elements and forceLinkClasses definitions. Allows an easier time migrating projects for #28 and future changes.

Initial implementation included a `withXml` function for futureproofing, but this is actually based on an internal gradle api.

**This is a breaking change, and will complain to users when they have the legacy jni/robovm.xml file still in their project.**