### PR TITLE
Fix iOS detection for MOE backend

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -45,7 +45,7 @@ public class SharedLibraryLoader {
 	static public boolean is64Bit = System.getProperty("os.arch").contains("64") || System.getProperty("os.arch").startsWith("armv8");
 
 	static {
-		boolean isMOEiOS = "iOS".equals(System.getProperty("moe.platform.name"));
+		boolean isMOEiOS = System.getProperty("moe.platform.name") != null;
 		String vm = System.getProperty("java.runtime.name");
 		if (vm != null && vm.contains("Android Runtime")) {
 			isAndroid = true;


### PR DESCRIPTION
The "moe.platform.name" property has changed in MOE. Simply checking whether the property is set resolves the issue.
This shouldn't have any negative consequences on any other platform. 