### PR TITLE
Fix issue that info.plist file isn't included into final jar

### DIFF
--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenIOSJarTask.java
@@ -15,6 +15,7 @@ public class JnigenIOSJarTask extends JnigenJarTask {
 
 		String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder;
 		from(path, (copySpec) -> {
+			copySpec.include("**/*.xcframework/");
 			copySpec.include("**/*.framework/");
 			copySpec.include("**/*.a");
 			copySpec.into("META-INF/robovm/ios/libs");


### PR DESCRIPTION
When I added xcframework support I forgot to let jnigen jar task also include the "Info.plist" file. This is the fix for this.