### PR TITLE
fix: Stop silent failure if NDK or compiler is not present

### DIFF
--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-android.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-android.xml.template
@@ -29,5 +29,6 @@
 		<condition property="has-ndk-build">
 			<equals arg1="${ndk-build-found}" arg2="true"/>
 		</condition>
+        <fail message="ndk-build not found. Have you set NDK_HOME?" unless="has-ndk-build"/>
 	</target>
 </project>

--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -89,6 +89,7 @@
 				</not>
 			</and>
 		</condition>
+        <fail message="Compiler ${gcc} or ${g++} not found." unless="has-compiler"/>
 		%precompile%
 	</target>
 	


### PR DESCRIPTION
Outstanding might be, what to do if stripper resolve fails?

Fixes https://github.com/libgdx/gdx-jnigen/issues/43