### PR TITLE
fix: Enforce UTF-8 for javah to prevent lockup

### DIFF
--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -301,7 +301,7 @@ public class NativeCodeGenerator {
 	private void generateHFiles (FileDescriptor file) throws Exception {
 		//Use temporary directory to prevent javac from creating class files somewhere we care about.
 		File tempClassFilesDirectory = Files.createTempDirectory("gdx-jnigen").toFile();
-		String command = "javac -classpath " + classpath + " -d " + tempClassFilesDirectory.getAbsolutePath() + " -h " + jniDir.path() + " " + file.path();
+		String command = "javac -Dfile.encoding=UTF-8 -classpath " + classpath + " -d " + tempClassFilesDirectory.getAbsolutePath() + " -h " + jniDir.path() + " " + file.path();
 		Process process = Runtime.getRuntime().exec(command);
 		process.waitFor();
 		if (process.exitValue() != 0) {


### PR DESCRIPTION
Fixes https://github.com/libgdx/gdx-jnigen/issues/42