### PR TITLE
Fix library loading on android

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/SharedLibraryLoader.java
@@ -147,6 +147,8 @@ public class SharedLibraryLoader {
 
 	/** Maps a platform independent library name to a platform dependent name. */
 	public String mapLibraryName (String libraryName) {
+		if (os == Os.Android)
+			return libraryName;
 		return os.getLibPrefix() + libraryName + architecture.toSuffix() + bitness.toSuffix() + "." + os.getLibExtension();
 	}
 


### PR DESCRIPTION
On android we load natives with
```
System.loadLibrary(platformName);
```
which expects unprocessed libname:
```
Loads the native library specified by the libname argument. The libname argument must not contain any platform specific prefix, file extension or path.
```