### PR TITLE
Add marker artifact to gradle plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,13 @@ We recommend you look at some existing projects for examples:
 - [gdx-video-desktop](https://github.com/libgdx/gdx-video/blob/master/gdx-video-desktop/build.gradle)
 - [Jamepad](https://github.com/libgdx/Jamepad/blob/master/build.gradle)
 
-```
-// Add buildscript dependency
-buildscript {
-    dependencies {
-        classpath "com.badlogicgames.gdx:gdx-jnigen-gradle:2.X.X"
-    }
+```gradle
+// Apply jnigen plugin
+plugins {
+    id "com.badlogicgames.gdx.gdx-jnigen"
 }
 
-// Apply jnigen plugin
-apply plugin: "com.badlogicgames.gdx.gdx-jnigen"
-
-...
+// ...
 
 // Define jnigen extension
 jnigen {

--- a/gdx-jnigen-gradle/build.gradle
+++ b/gdx-jnigen-gradle/build.gradle
@@ -1,4 +1,17 @@
+plugins {
+    id 'java-gradle-plugin'
+}
+
 dependencies {
     implementation project(":gdx-jnigen")
     implementation gradleApi()
+}
+
+gradlePlugin {
+    plugins {
+        register('gdxJniGen') {
+            id = 'com.badlogicgames.gdx.gdx-jnigen'
+            implementationClass = 'com.badlogic.gdx.jnigen.gradle.JnigenPlugin'
+        }
+    }
 }

--- a/gdx-jnigen-gradle/src/main/resources/META-INF/gradle-plugins/com.badlogicgames.gdx.gdx-jnigen.properties
+++ b/gdx-jnigen-gradle/src/main/resources/META-INF/gradle-plugins/com.badlogicgames.gdx.gdx-jnigen.properties
@@ -1,1 +1,0 @@
-implementation-class=com.badlogic.gdx.jnigen.gradle.JnigenPlugin


### PR DESCRIPTION
Closes #58 

This PR adds the `java-gradle-plugin` to the project, and sets up an ID for the plugin (I put something I thought might make sense, but I'm happy to change it to whatever).

As  a side effect, this will add an extra publication in the form of a [gradle marker artifact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) which will allow using this plugin by referring to its ID.

```gradle

plugins {
  id 'com.badlogicgames.gdx.gdx-jnigen'
}
```

The plugin properties file has been removed as the `java-gradle-plugin` plugin already generates it.

I tested this only using `publishToMavenLocal` and it created all the publications for me - not sure how to test it elsewhere:

![image](https://github.com/libgdx/gdx-jnigen/assets/1263058/0cf7bcef-0e81-4348-b773-72c572d0d954)
