### PR TITLE
fix: Ensure to load resource with global class loader

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -182,7 +182,7 @@ public class SharedLibraryLoader {
 
 	private InputStream readFile (String path) {
 		if (nativesJar == null) {
-			InputStream input = SharedLibraryLoader.class.getResourceAsStream("/" + path);
+			InputStream input = SharedLibraryLoader.class.getClassLoader().getResourceAsStream(path);
 			if (input == null) throw new SharedLibraryLoadRuntimeException("Unable to read file for extraction: " + path);
 			return input;
 		}


### PR DESCRIPTION
# Description

When `gdx-jnigen-loader` is put on the module path (to be loaded as an automatically named module in JPMS), it cannot load any libraries in a separate JAR anymore. This patch contains a simple fix to hopefully make things work when `gdx-jnigen-loader` is used as a named module.

# Explanation

After Java 9, all classes are put within some modules. There are three kinds of modules:

1. Unnamed modules: where classes from class path are put.
2. Automatic modules: where classes from module path are put when the JAR doesn't explicitly declare a module.
3. Explicitly declared modules.

With JPMS, `Class#getResource` by default loads resources only
from the current module, making `SharedLibraryLoader` malfunction,
whose purpose is to load libraries from other JARs (modules). In contrast, `ClassLoader#getResource` tries to find resources from all loaded modules, which should be used instead to allow using `jnigen` as an automatic module.

# Reproducing Steps

## Preparations

```console
$ # The jnigen loader JAR
$ wget https://repo1.maven.org/maven2/com/badlogicgames/gdx/gdx-jnigen-loader/2.5.1/gdx-jnigen-loader-2.5.1.jar
$ # A JAR containing binaries built with jnigen
$ wget https://repo1.maven.org/maven2/party/iroiro/luajava/lua54-platform/3.5.0/lua54-platform-3.5.0-natives-desktop.jar
```

## A Working Example

```console
$ jshell --class-path lua54-platform-3.5.0-natives-desktop.jar:gdx-jnigen-loader-2.5.1.jar
jshell> import com.badlogic.gdx.utils.SharedLibraryLoader;
jshell> var loader = new SharedLibraryLoader();
jshell> loader.load("lua54");
jshell> // Library loaded with no exception thrown
```

## A Failing One

```console
$ jshell --module-path lua54-platform-3.5.0-natives-desktop.jar:gdx-jnigen-loader-2.5.1.jar --add-module gdx.jnigen.loader
jshell> import com.badlogic.gdx.utils.SharedLibraryLoader;
jshell> var loader = new SharedLibraryLoader();
jshell> loader.load("lua54");
|  Exception com.badlogic.gdx.utils.SharedLibraryLoadRuntimeException: Couldn't load shared library 'liblua5464.so' for target: Linux, x86, 64-bit
|        at SharedLibraryLoader.load (SharedLibraryLoader.java:174)
|        at (#4:1)
|  Caused by: com.badlogic.gdx.utils.SharedLibraryLoadRuntimeException: Unable to read file for extraction: liblua5464.so
|        at SharedLibraryLoader.readFile (SharedLibraryLoader.java:183)
|        at SharedLibraryLoader.loadFile (SharedLibraryLoader.java:339)
|        at SharedLibraryLoader.load (SharedLibraryLoader.java:170)
|        ...
```
