### PR TITLE
Add LOONGARCH to JnigenExtension as shortcut and bump version

### DIFF
--- a/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -34,6 +34,7 @@ public class JnigenExtension {
 	public static final Architecture x86 = Architecture.x86;
 	public static final Architecture ARM = Architecture.ARM;
 	public static final Architecture RISCV = Architecture.RISCV;
+	public static final Architecture LOONGARCH = Architecture.LOONGARCH;
 	public static final Os Windows = Os.Windows;
 	public static final Os Linux = Os.Linux;
 	public static final Os MacOsX = Os.MacOsX;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.badlogicgames.gdx
-version=2.5.1
+version=2.5.2
 POM_DESCRIPTION=libGDX jnigen library
 POM_NAME=libGDX jnigen library
 POM_URL=https://github.com/libgdx/gdx-jnigen


### PR DESCRIPTION
Minor QOL and fixes the missed version bump after the 2.5.1 release