### PR TITLE
Allow processing all files that are defined by the includes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [2.5.2]
+- Compile all files that are defined by cIncludes/cExcludes/cppIncludes/cppExcludes
 - Add support for defining multiple source directories in the gradle plugin
 
 [2.5.1]

--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-ios.xml.template
@@ -111,8 +111,7 @@
 			<targetfile/>
 			<fileset refid="g++-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.cpp" to="*.o"/>
-				<mapper type="glob" from="*.mm" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 		<apply failonerror="true" executable="${gcc}" dest="${buildDir}/x86_64" verbose="true">
@@ -127,7 +126,7 @@
 			<targetfile/>
 			<fileset refid="gcc-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.c" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 	</target>
@@ -165,8 +164,7 @@
             <targetfile/>
             <fileset refid="g++-files"/>
             <compositemapper>
-                <mapper type="glob" from="*.cpp" to="*.o"/>
-                <mapper type="glob" from="*.mm" to="*.o"/>
+                <mapper type="glob" from="*" to="*.o"/>
             </compositemapper>
         </apply>
         <apply failonerror="true" executable="${gcc}" dest="${buildDir}/arm64-simulator" verbose="true">
@@ -181,7 +179,7 @@
             <targetfile/>
             <fileset refid="gcc-files"/>
             <compositemapper>
-                <mapper type="glob" from="*.c" to="*.o"/>
+                <mapper type="glob" from="*" to="*.o"/>
             </compositemapper>
         </apply>
     </target>
@@ -218,8 +216,7 @@
 			<targetfile/>
 			<fileset refid="g++-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.cpp" to="*.o"/>
-				<mapper type="glob" from="*.mm" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 		<apply failonerror="true" executable="${gcc}" dest="${buildDir}/arm64" verbose="true">
@@ -234,7 +231,7 @@
 			<targetfile/>
 			<fileset refid="gcc-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.c" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 	</target>

--- a/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
+++ b/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/build-target.xml.template
@@ -121,8 +121,7 @@
 			<targetfile/>
 			<fileset refid="g++-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.cpp" to="*.o"/>
-				<mapper type="glob" from="*.mm" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 		<apply failonerror="true" executable="${gcc}" dest="${buildDir}" verbose="true">
@@ -136,8 +135,7 @@
 			<targetfile/>
 			<fileset refid="gcc-files"/>
 			<compositemapper>
-				<mapper type="glob" from="*.c" to="*.o"/>
-				<mapper type="glob" from="*.m" to="*.o"/>
+				<mapper type="glob" from="*" to="*.o"/>
 			</compositemapper>
 		</apply>
 	</target>	


### PR DESCRIPTION
The files which are compiled are already defined by the `c(pp)Includes/Excludes`, therefor we should just accept what is defined by them.
This allows for compiling more files with other extension, like `.cc` or `.S`.

This might be a little breaking, if some user defined incorrect includes, that got filtered out so far by their wrong file extension. However, I think that is rather minor.