### PR TITLE
Upgrade default minIOSVersion to 12.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 [2.5.2]
+- [BREAKING CHANGE] Increased default `minIOSVersion` to iOS 12. Default can be overridden with `minIOSVersion = "11.0"`
 - Compile all files that are defined by cIncludes/cExcludes/cppIncludes/cppExcludes
 - Add support for defining multiple source directories in the gradle plugin
 

--- a/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -85,8 +85,8 @@ public class BuildTarget {
 	public String[] androidApplicationMk = {};
 	/** ios framework bundle identifier, if null an automatically generated bundle identifier will be used */
 	public String xcframeworkBundleIdentifier = null;
-	/** Minimum supported iOS version, will default to iOS 11*/
-	public String minIOSVersion = "11.0";
+	/** Minimum supported iOS version, will default to iOS 12*/
+	public String minIOSVersion = "12.0";
 
 	/** Creates a new build target. See members of this class for a description of the parameters. */
 	public BuildTarget(Os targetType, Architecture.Bitness bitness, String[] cIncludes, String[] cExcludes, String[] cppIncludes, String[] cppExcludes, String[] headerDirs, String compilerPrefix, String cFlags, String cppFlags, String linkerFlags) {


### PR DESCRIPTION
Discussion was held here: https://github.com/libgdx/libgdx/pull/7376

In short, XCode 15 removed iOS 11 deployment support, so we follow that, since the iOS 11 market share is very small.