### PR TITLE
Correctly define android file extension as ".so" to fix jaring

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/Os.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/utils/Os.java
@@ -22,6 +22,7 @@ public enum Os {
 		if (this == Os.Windows) return "dll";
 		if (this == Os.Linux) return "so";
 		if (this == Os.MacOsX) return "dylib";
+		if (this == Os.Android) return "so";
 		return "";
 	}
 }


### PR DESCRIPTION
This fixes android lib jaring.

The jar task determines the include paths by:
```java 
String path = ext.subProjectDir + ext.libsDir + File.separatorChar + targetFolder + File.separatorChar + target.getSharedLibFilename(ext.sharedLibName);
```
where `target.getSharedLibFilename(ext.sharedLibName);` will build up the file like:
```java
		String suffix = os.getLibExtension().isEmpty() ? "" : "." + os.getLibExtension();

		// generate shared lib prefix and suffix, determine jni platform headers directory
		return os.getLibPrefix() + sharedLibName + architecture.toSuffix() + bitness.toSuffix() + suffix;
```
since suffix for android was empty, it didn't set the file extension correctly and didn't maged the ".so" files.

This should have no side effects, since the jar task is the only place that effectivly uses the value for android.