### PR TITLE
Allow overriding Android library loading logic

### DIFF
--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/AndroidLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/AndroidLibraryLoader.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.badlogic.gdx.jnigen.loader;
+
+/** Loader for native libraries in Android. */
+public interface AndroidLibraryLoader {
+
+    /** Loads a native library. */
+    void load(String name);
+}

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -44,6 +44,18 @@ public class SharedLibraryLoader {
 	static private final HashSet<String> loadedLibraries = new HashSet<>();
 	static private final Random random = new Random();
 
+	static private AndroidLibraryLoader androidLibraryLoader = new AndroidLibraryLoader() {
+		@Override
+		public void load(String name) {
+			System.loadLibrary(name);
+		}
+	};
+
+	/** Sets a custom library loader for Android. */
+	public static void setAndroidLibraryLoader(AndroidLibraryLoader loader) {
+		androidLibraryLoader = loader;
+	}
+
 	private String nativesJar;
 
 	public SharedLibraryLoader () {
@@ -95,7 +107,7 @@ public class SharedLibraryLoader {
 			String platformName = mapLibraryName(libraryName);
 			try {
 				if (HostDetection.os == Os.Android)
-					System.loadLibrary(platformName);
+					androidLibraryLoader.load(platformName);
 				else
 					loadFile(platformName);
 				setLoaded(libraryName);


### PR DESCRIPTION
This PR adds the ability to configure how `SharedLibraryLoader` loads libraries in Android. This is to allow libraries to be used in different ways, for example by using ReLinker.

Initial discussion in https://github.com/libgdx/gdx-liftoff/pull/158, where I was suggested this is a better place for the configuration to exist, as it's also used in other projects (for example box2d bindings).