### PR TITLE
Thread attach rework

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test-macos:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
         with:
@@ -32,7 +32,7 @@ jobs:
           # See https://github.com/actions/virtual-environments/issues/2557
           sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
           sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
-          sudo mv /Applications/Xcode_14.3.1.app /Applications/Xcode.app
+          sudo mv /Applications/Xcode_15.4.0.app /Applications/Xcode.app
           sudo xcode-select -switch /Applications/Xcode.app
           /usr/bin/xcodebuild -version
           ./gradlew build_macos

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,170 @@
+name: Build and test pullrequest
+
+on:
+  pull_request:
+    branches: [ master ]
+permissions:
+  contents: read
+
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build macOS natives
+        run: |
+          # See https://github.com/actions/virtual-environments/issues/2557
+          sudo mv /Library/Developer/CommandLineTools/SDKs/* /tmp
+          sudo mv /Applications/Xcode.app /Applications/Xcode.app.bak
+          sudo mv /Applications/Xcode_14.3.1.app /Applications/Xcode.app
+          sudo xcode-select -switch /Applications/Xcode.app
+          /usr/bin/xcodebuild -version
+          ./gradlew build_macos
+          ./gradlew jniGen jnigenBuildAllMacOsX
+
+      - name: Run test on macos
+        run: |
+          ./gradlew test 
+
+  test-linux:
+    runs-on: ubuntu-20.04
+    container:
+      image: ubuntu:18.04
+    steps:
+      - name: Install dependencies into minimal dockerfile
+        run: |
+          # ubuntu dockerfile is very minimal (only 122 packages are installed)
+          # need to install updated git (from official git ppa)
+          apt update
+          apt install -y software-properties-common
+          add-apt-repository ppa:git-core/ppa -y
+          # install dependencies expected by other steps
+          apt update
+          apt install -y git \
+          curl \
+          ca-certificates \
+          wget \
+          bzip2 \
+          zip \
+          unzip \
+          xz-utils \
+          maven \
+          ant sudo locales make texinfo
+
+          # set Locale to en_US.UTF-8 (avoids hang during compilation)
+          locale-gen en_US.UTF-8
+          echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
+          echo "LANGUAGE=en_US.UTF-8" >> $GITHUB_ENV
+          echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Install cross-compilation toolchains
+        run: |
+          sudo apt update
+          sudo apt install -y --force-yes gcc g++
+          sudo apt install -y --force-yes gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross
+          sudo apt install -y --force-yes gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf libc6-dev-armhf-cross
+          sudo apt install -y --force-yes gcc-riscv64-linux-gnu g++-riscv64-linux-gnu libc6-dev-riscv64-cross
+
+      - name: Build Linux natives
+        run: |
+          ./gradlew build_linux
+          ./gradlew jnigen jnigenBuildAllLinux 
+
+      - name: Run test on linux
+        run: |
+          ./gradlew test 
+
+  natives-windows:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Install cross-compilation toolchains
+        run: |
+          sudo apt update
+          sudo apt install -y --force-yes mingw-w64 lib32z1
+
+      - name: Build Windows natives
+        run: |
+          ./gradlew build_windows
+          ./gradlew jnigen jnigenBuildAllWindows
+
+      - name: Pack artifacts
+        run: |
+          find .  -name "*.a" -o -name "*.dll" -o -name "*.dylib" -o -name "*.so" | grep "libs" > native-files-list
+          zip natives-windows -@ < native-files-list
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: natives-windows.zip
+          path: natives-windows.zip
+
+  test-windows:
+    runs-on: windows-latest
+    needs: [natives-windows]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Download natives-windows artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: natives-windows.zip
+
+      - name: Run windows tests
+        run: |
+          ./gradlew test

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -243,9 +243,36 @@ jobs:
           name: natives-android.zip
           path: natives-android.zip
 
+  test-windows:
+    runs-on: windows-latest
+    needs: [natives-windows]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Download natives-windows artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: natives-windows.zip
+
+      - name: Run windows tests
+        run: |
+          ./gradlew test
+
   publish:
     runs-on: ubuntu-20.04
-    needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android]
+    needs: [natives-macos, natives-linux, natives-windows, natives-ios, natives-android, test-windows]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/gdx-jnigen-generator-test/build.gradle
+++ b/gdx-jnigen-generator-test/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     testRuntimeOnly fileTree(dir: file("build/jnigen/libs"), include: '*natives-desktop.jar')
     if (HostDetection.os === Os.Windows) {
         testImplementation "com.badlogicgames.jnigen:jnigen-runtime:3.0.0-SNAPSHOT"
-        testImplementation "com.badlogicgames.jnigen:jnigen-runtime:3.0.0-SNAPSHOT:natives-desktop"
+        testImplementation "com.badlogicgames.jnigen:jnigen-runtime-platform:3.0.0-SNAPSHOT:natives-desktop"
     } else {
         testImplementation project(path: ":jnigen-runtime")
         testImplementation project(path: ":jnigen-runtime", configuration: "archives")

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/Constants.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/Constants.java
@@ -18,7 +18,7 @@ public final class Constants {
 
     public static final byte UNSIGNED_INT = 10;
 
-    public static final byte boolean_r = 10;
+    public static final byte final_r = 10;
 
     public static final byte special1 = 10;
 

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/TestData.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/TestData.java
@@ -885,6 +885,16 @@ static jclass cxxExceptionClass = NULL;
     	return 0;
     */
 
+    public static void call_callback_in_thread(ClosureObject<thread_callback> thread_callback) {
+        call_callback_in_thread_internal(thread_callback.getFnPtr());
+    }
+
+    static private native void call_callback_in_thread_internal(long thread_callback);/*
+    	HANDLE_JAVA_EXCEPTION_START()
+    	call_callback_in_thread((void *(*)(void *))thread_callback);
+    	HANDLE_JAVA_EXCEPTION_END()
+    */
+
     public interface methodWithCallbackBooleanArg extends com.badlogic.gdx.jnigen.runtime.closure.Closure {
 
         com.badlogic.gdx.jnigen.runtime.c.CTypeInfo[] __ffi_cache = new com.badlogic.gdx.jnigen.runtime.c.CTypeInfo[] { FFITypes.getCTypeInfo(-2), FFITypes.getCTypeInfo(0) };
@@ -1351,6 +1361,21 @@ static jclass cxxExceptionClass = NULL;
 
         default void invoke(com.badlogic.gdx.jnigen.runtime.ffi.JavaTypeWrapper[] parameters, com.badlogic.gdx.jnigen.runtime.ffi.JavaTypeWrapper returnType) {
             methodWithIntPtrPtrArg_call(new PointerPointer<>(parameters[0].asLong(), false, (long peer2, boolean owned2) -> new CSizedIntPointer(peer2, owned2, "int")).setBackingCType("int"));
+        }
+    }
+
+    public interface thread_callback extends com.badlogic.gdx.jnigen.runtime.closure.Closure {
+
+        com.badlogic.gdx.jnigen.runtime.c.CTypeInfo[] __ffi_cache = new com.badlogic.gdx.jnigen.runtime.c.CTypeInfo[] { FFITypes.getCTypeInfo(-1), FFITypes.getCTypeInfo(-1) };
+
+        VoidPointer thread_callback_call(VoidPointer arg0);
+
+        default com.badlogic.gdx.jnigen.runtime.c.CTypeInfo[] functionSignature() {
+            return __ffi_cache;
+        }
+
+        default void invoke(com.badlogic.gdx.jnigen.runtime.ffi.JavaTypeWrapper[] parameters, com.badlogic.gdx.jnigen.runtime.ffi.JavaTypeWrapper returnType) {
+            returnType.setValue(thread_callback_call(new VoidPointer(parameters[0].asLong(), false)));
         }
     }
 

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/tests/ClosureTest.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/tests/ClosureTest.java
@@ -229,4 +229,17 @@ public class ClosureTest extends BaseTest {
         assertEquals(55.55, ret);
         closureObject.free();
     }
+
+    @Test
+    public void closureFromThread() {
+        AtomicReference<String> spawnedThreadName = new AtomicReference<>();
+        ClosureObject<thread_callback> closureObject = ClosureObject.fromClosure((arg) -> {
+            spawnedThreadName.set(Thread.currentThread().getName());
+            return arg;
+        });
+        call_callback_in_thread(closureObject);
+        assertNotEquals(spawnedThreadName.get(), Thread.currentThread().getName());
+        assertTrue(spawnedThreadName.get().startsWith("Thread-"));
+        closureObject.free();
+    }
 }

--- a/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
+++ b/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
@@ -414,4 +414,21 @@ void ensureParsed(AnonymousStructNoField, AnonymousStructField, AnonymousStructF
 void weirdPointer(FILE *_file) {}
 void constArrayParameter(const TestStruct structs[]) {}
 
+#ifdef _WIN32
+#include <windows.h>
+
+void call_callback_in_thread(void* (*thread_callback)(void*)) {
+    HANDLE thread = CreateThread(NULL, 0, thread_callback, NULL, 0, NULL);
+    WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+}
+#else
+#include <pthread.h>
+
+void call_callback_in_thread(void* (*thread_callback)(void*)) {
+    pthread_t thread;
+    pthread_create(&thread, NULL, thread_callback, NULL);
+    pthread_join(thread, NULL);
+}
+#endif
 

--- a/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
+++ b/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
@@ -417,8 +417,14 @@ void constArrayParameter(const TestStruct structs[]) {}
 #ifdef _WIN32
 #include <windows.h>
 
+DWORD WINAPI thread_wrapper(LPVOID param) {
+    auto callback = static_cast<void* (*)(void*)>(param);
+    callback(nullptr);
+    return 0;
+}
+
 void call_callback_in_thread(void* (*thread_callback)(void*)) {
-    HANDLE thread = CreateThread(NULL, 0, thread_callback, NULL, 0, NULL);
+    HANDLE thread = CreateThread(NULL, 0, thread_wrapper, reinterpret_cast<LPVOID>(thread_callback), 0, NULL);
     WaitForSingleObject(thread, INFINITE);
     CloseHandle(thread);
 }

--- a/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
+++ b/gdx-jnigen-generator-test/src/test/resources/test_data.cpp
@@ -418,7 +418,7 @@ void constArrayParameter(const TestStruct structs[]) {}
 #include <windows.h>
 
 DWORD WINAPI thread_wrapper(LPVOID param) {
-    auto callback = static_cast<void* (*)(void*)>(param);
+    auto callback = reinterpret_cast<void* (*)(void*)>(param);
     callback(nullptr);
     return 0;
 }

--- a/gdx-jnigen-generator-test/src/test/resources/test_data.h
+++ b/gdx-jnigen-generator-test/src/test/resources/test_data.h
@@ -268,6 +268,7 @@ const char* returnThrownCauseMessage(methodWithThrowingCallback fnPtr);
 char* returnString(void);
 bool validateString(char* str);
 
+void call_callback_in_thread(void* (*thread_callback)(void*));
 #ifdef __cplusplus
 }
 #endif

--- a/gdx-jnigen-generator-test/src/test/resources/test_data.h
+++ b/gdx-jnigen-generator-test/src/test/resources/test_data.h
@@ -16,7 +16,7 @@ extern "C" {
 #define SIGNED_DOUBLE -10.5
 #define UNSIGNED_HEX_INT 0x5B
 #define SIGNED_HEX_INT -0x5B
-#define boolean 10
+#define final 10
 #define special1 10L
 #define special2 10LLU
 #define special3 10.5

--- a/gdx-jnigen-runtime/build.gradle
+++ b/gdx-jnigen-runtime/build.gradle
@@ -184,6 +184,7 @@ jnigen {
 
         headerDirs += ["build/libffi-build/${combined}/include/", "src/main/native"]
         cppIncludes += ["src/main/native/*.cpp"]
+        cIncludes += ["src/main/native/*.c"]
         cFlags += " -std=c11 -fexceptions "
         cppFlags += " -std=c++11 -fexceptions "
         libraries += file("build/libffi-build/${combined}/lib/libffi.a").absolutePath

--- a/gdx-jnigen-runtime/src/main/native/CHandler.h
+++ b/gdx-jnigen-runtime/src/main/native/CHandler.h
@@ -207,6 +207,9 @@ JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_jnigen_runtime_CHandler_clone
 JNIEXPORT jlong JNICALL Java_com_badlogic_gdx_jnigen_runtime_CHandler_convertNativeTypeToFFIType
   (JNIEnv *, jclass, jlong);
 
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved);
+JNIEXPORT void JNICALL JNI_OnUnload(JavaVM *vm, void *reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gdx-jnigen-runtime/src/main/native/jni_env_tls.c
+++ b/gdx-jnigen-runtime/src/main/native/jni_env_tls.c
@@ -26,7 +26,7 @@ DWORD envTls = TLS_OUT_OF_INDEXES;
 BOOL WINAPI DllMain(HINSTANCE hDLL, DWORD fdwReason, LPVOID lpvReserved) {
     // Docs say no cleanup when lpvReserved != NULL
     if (fdwReason == DLL_THREAD_DETACH && lpvReserved == NULL) {
-        ThreadData* t_data = (ThreadData*)TlsGetValue(envTLS);
+        ThreadData* t_data = (ThreadData*)TlsGetValue(envTls);
         detach_jni_env(t_data);
     }
 
@@ -34,11 +34,11 @@ BOOL WINAPI DllMain(HINSTANCE hDLL, DWORD fdwReason, LPVOID lpvReserved) {
 }
 
 void init_tls() {
-    if (envTLS != TLS_OUT_OF_INDEXES) {
+    if (envTls != TLS_OUT_OF_INDEXES) {
         HANDLE_RESULT(-1, "TLS got double initialized")
     }
-    envTLS = TlsAlloc();
-    if (envTLS == TLS_OUT_OF_INDEXES) {
+    envTls = TlsAlloc();
+    if (envTls == TLS_OUT_OF_INDEXES) {
         HANDLE_RESULT(-1, "Failed to allocate TLS")
     }
 }
@@ -51,9 +51,9 @@ void cleanup_tls() {
 }
 
 void set_tls(ThreadData* t_data) {
-    if (envTLS == TLS_OUT_OF_INDEXES) 
+    if (envTls == TLS_OUT_OF_INDEXES)
         init_tls();
-    BOOL res = TlsSetValue(envTLS, (LPVOID)data);;
+    BOOL res = TlsSetValue(envTls, (LPVOID)t_data);;
     HANDLE_RESULT(res, "Failed to set thread data")
 }
 

--- a/gdx-jnigen-runtime/src/main/native/jni_env_tls.c
+++ b/gdx-jnigen-runtime/src/main/native/jni_env_tls.c
@@ -1,0 +1,110 @@
+#include "jni_env_tls.h"
+#include <stdlib.h>
+#ifdef _WIN32
+#include <process.h>
+#include <processthreadsapi.h>
+#else
+#include <pthread.h>
+#endif
+
+#ifdef __ANDROID__
+#define THREAD_ATTACH_MACRO (*vm)->AttachCurrentThreadAsDaemon(vm, env, NULL);
+#else
+#define THREAD_ATTACH_MACRO (*vm)->AttachCurrentThreadAsDaemon(vm, (void**)env, NULL);
+#endif
+
+#define HANDLE_RESULT(res, msg) \
+    if (res != JNI_OK) { \
+        fprintf(stderr, msg ": %d", res); \
+        fflush(stderr); \
+        exit(1); \
+    }
+
+#ifdef _WIN32
+DWORD envTls = TLS_OUT_OF_INDEXES;
+
+BOOL WINAPI DllMain(HINSTANCE hDLL, DWORD fdwReason, LPVOID lpvReserved) {
+    // Docs say no cleanup when lpvReserved != NULL
+    if (fdwReason == DLL_THREAD_DETACH && lpvReserved == NULL) {
+        ThreadData* t_data = (ThreadData*)TlsGetValue(envTLS);
+        detach_jni_env(t_data);
+    }
+
+    return TRUE;
+}
+
+void init_tls() {
+    if (envTLS != TLS_OUT_OF_INDEXES) {
+        HANDLE_RESULT(-1, "TLS got double initialized")
+    }
+    envTLS = TlsAlloc();
+    if (envTLS == TLS_OUT_OF_INDEXES) {
+        HANDLE_RESULT(-1, "Failed to allocate TLS")
+    }
+}
+
+void cleanup_tls() {
+    if (envTls != TLS_OUT_OF_INDEXES) {
+        BOOL res = TlsFree(envTls);
+        HANDLE_RESULT(res, "Failed to deallocate TLS")
+    }
+}
+
+void set_tls(ThreadData* t_data) {
+    if (envTLS == TLS_OUT_OF_INDEXES) 
+        init_tls();
+    BOOL res = TlsSetValue(envTLS, (LPVOID)data);;
+    HANDLE_RESULT(res, "Failed to set thread data")
+}
+
+#else
+pthread_key_t envTlsKey = 0;
+
+void init_tls() {
+    HANDLE_RESULT(envTlsKey, "TLS got double initialized")
+        
+    int res = pthread_key_create(&envTlsKey, detach_jni_env);
+    HANDLE_RESULT(res, "Failed to create pthread key")
+}
+
+void cleanup_tls() {
+    if (envTlsKey != 0) {
+        int res = pthread_key_delete(envTlsKey);
+        HANDLE_RESULT(res, "Failed to delete pthread key")
+        envTlsKey = 0;
+    }
+}
+
+void set_tls(ThreadData* t_data) {
+    if (envTlsKey == 0)
+        init_tls();
+    int p_res = pthread_setspecific(envTlsKey, t_data);
+    HANDLE_RESULT(p_res, "Failed to set thread data")
+}
+#endif
+
+
+void detach_jni_env(void* data) {
+    ThreadData* t_data = data;
+    JavaVM* vm = t_data->vm;
+
+    jint res = (*vm)->DetachCurrentThread(vm);
+    HANDLE_RESULT(res, "Failed to detach thread")
+
+    free(t_data);
+}
+
+void tls_attach_jni_env(JavaVM* vm, JNIEnv** env) {
+    jint attach_res = (*vm)->GetEnv(vm, (void**)env, JNI_VERSION_1_6);
+    if (attach_res == JNI_EDETACHED) {
+        jint res = THREAD_ATTACH_MACRO
+        HANDLE_RESULT(res, "Failed to attach thread")
+        ThreadData* t_data = malloc(sizeof(ThreadData));
+        t_data->env = *env;
+        t_data->vm = vm;
+        
+        set_tls(t_data);
+    } else {
+        HANDLE_RESULT(attach_res, "Failed to get thread")
+    }
+}

--- a/gdx-jnigen-runtime/src/main/native/jni_env_tls.h
+++ b/gdx-jnigen-runtime/src/main/native/jni_env_tls.h
@@ -1,0 +1,23 @@
+#ifndef JNI_ENV_TLS_H_
+#define JNI_ENV_TLS_H_
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ThreadData {
+    JavaVM* vm;
+    JNIEnv* env;
+} ThreadData;
+
+void init_tls();
+void cleanup_tls();
+void tls_attach_jni_env(JavaVM* vm, JNIEnv** env);
+void detach_jni_env(void* data);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // JNI_ENV_TLS_H_


### PR DESCRIPTION
As discovered by `fgnm` on discord, Attaching/Detaching can accumulate lots of garbage in a short period of time.
This tries to solve this by attaching once and detaching once the thread dies.

This is untested on windows.