### PR TITLE
Delay resolve of llvm dependency until generate task execution

### DIFF
--- a/compiling/gdx-jnigen-generator/build.gradle
+++ b/compiling/gdx-jnigen-generator/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.bytedeco:llvm:16.0.4-1.5.9'
-    implementation 'com.github.javaparser:javaparser-core:3.25.9'
+    implementation 'org.bytedeco:llvm:19.1.3-1.5.11'
+    implementation 'com.github.javaparser:javaparser-core:3.26.3'
 }

--- a/compiling/gdx-jnigen-generator/build.gradle
+++ b/compiling/gdx-jnigen-generator/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.bytedeco:llvm-platform:16.0.4-1.5.9'
+    implementation 'org.bytedeco:llvm:16.0.4-1.5.9'
     implementation 'com.github.javaparser:javaparser-core:3.25.9'
 }

--- a/compiling/gdx-jnigen-gradle/build.gradle
+++ b/compiling/gdx-jnigen-gradle/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(":jnigen-core")
-    implementation gradleApi()
+    compileOnly gradleApi()
     implementation project(":jnigen-generator")
 }
 

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
@@ -32,7 +32,7 @@ public class JnigenGenerateBindingsTask extends DefaultTask {
             conf.setDescription("LLVM dependencies for generator");
         });
 
-        getProject().getDependencies().add("generatorLLVM", "org.bytedeco:llvm-platform:16.0.4-1.5.9");
+        getProject().getDependencies().add("generatorLLVM", "org.bytedeco:llvm-platform:19.1.3-1.5.11");
 
         this.configuration = llvmConfiguration;
     }
@@ -68,6 +68,7 @@ public class JnigenGenerateBindingsTask extends DefaultTask {
         args.addAll(Arrays.asList(options));
 
         getProject().javaexec(spec -> {
+            spec.environment("LIBCLANG_DISABLE_CRASH_RECOVERY", "1");
             spec.setClasspath(filteredClasspath.plus(configuration));
             spec.getMainClass().set("com.badlogic.gdx.jnigen.generator.Generator");
             spec.args(args);

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
@@ -1,15 +1,22 @@
 package com.badlogic.gdx.jnigen.gradle;
 
-import com.badlogic.gdx.jnigen.generator.Generator;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class JnigenGenerateBindingsTask extends DefaultTask {
 
     private final JnigenBindingGeneratorExtension ext;
+    private Configuration configuration;
+
     @Inject
     public JnigenGenerateBindingsTask(JnigenExtension ext) {
         this.ext = ext.generator;
@@ -17,6 +24,22 @@ public class JnigenGenerateBindingsTask extends DefaultTask {
         setGroup("jnigen");
 
         setDescription("Generates java jnigen binding code.");
+
+        Configuration llvmConfiguration = getProject().getConfigurations().create("generatorLLVM", conf -> {
+            conf.setVisible(false);
+            conf.setCanBeResolved(true);
+            conf.setCanBeConsumed(false);
+            conf.setDescription("LLVM dependencies for generator");
+        });
+
+        getProject().getDependencies().add("generatorLLVM", "org.bytedeco:llvm-platform:16.0.4-1.5.9");
+
+        this.configuration = llvmConfiguration;
+    }
+
+    @Classpath
+    public Configuration getConfiguration() {
+        return configuration;
     }
 
     @TaskAction
@@ -24,9 +47,30 @@ public class JnigenGenerateBindingsTask extends DefaultTask {
         Objects.requireNonNull(ext.getOutputPath(), "jnigen.generator.outputPath not defined");
         Objects.requireNonNull(ext.getBasePackage(), "jnigen.generator.basePackage not defined");
         Objects.requireNonNull(ext.getFileToParse(), "jnigen.generator.fileToParse not defined");
+
+        // Gradle is annoying and ships it's own javaparser, but doesn't relocate it
+        FileCollection filteredClasspath = getProject().files(
+                getProject().getBuildscript()
+                        .getConfigurations().getByName("classpath")
+                        .resolve().stream()
+                        .filter(file -> !file.getAbsolutePath().contains("gradle-"))
+                        .collect(Collectors.toList())
+        );
+
         String[] options = ext.getOptions();
         if (options == null)
             options = new String[0];
-        Generator.execute(ext.getOutputPath().getAbsolutePath(), ext.getBasePackage(), ext.getFileToParse(), options);
+
+        ArrayList<String> args = new ArrayList<>();
+        args.add(ext.getOutputPath().getAbsolutePath());
+        args.add(ext.getBasePackage());
+        args.add(ext.getFileToParse());
+        args.addAll(Arrays.asList(options));
+
+        getProject().javaexec(spec -> {
+            spec.setClasspath(filteredClasspath.plus(configuration));
+            spec.getMainClass().set("com.badlogic.gdx.jnigen.generator.Generator");
+            spec.args(args);
+        });
     }
 }


### PR DESCRIPTION
llvm is biiiiiiiiiiig. Let's not force all users to download it, only if they execute the generate task