### PR TITLE
Make relevant fields public for gradle modification

### DIFF
--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -287,10 +287,10 @@ public class JnigenExtension {
     }
 
     public class NativeCodeGeneratorConfig {
-        SourceSet sourceSet;
+        public SourceSet sourceSet;
+        public String[] includes = null;
+        public String[] excludes = null;
         private String[] sourceDirs;
-        String[] includes = null;
-        String[] excludes = null;
 
         public NativeCodeGeneratorConfig (Project project) {
             JavaPluginConvention javaPlugin = project.getConvention().getPlugin(JavaPluginConvention.class);

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -54,20 +54,20 @@ public class JnigenExtension {
      * Gradle Tasks are executed in the main project working directory. Supply
      * actual subproject path where necessary.
      */
-    String subProjectDir;
+    public String subProjectDir;
 
-    String sharedLibName = null;
-    String temporaryDir = "build/jnigen/target";
-    String libsDir = "build/jnigen/libs";
-    String jniDir = "build/jnigen/jni";
+    public String sharedLibName = null;
+    public String temporaryDir = "build/jnigen/target";
+    public String libsDir = "build/jnigen/libs";
+    public String jniDir = "build/jnigen/jni";
 
     /**
      * If we should build with release flag set.<br/>
      * This strips debug symbols.
      */
-    boolean release = true;
+    public boolean release = true;
 
-    boolean multiThreadedCompile = true;
+    public boolean multiThreadedCompile = true;
 
     NativeCodeGeneratorConfig nativeCodeGeneratorConfig;
     public List<BuildTarget> targets = new ArrayList<>();
@@ -286,7 +286,7 @@ public class JnigenExtension {
         }
     }
 
-    class NativeCodeGeneratorConfig {
+    public class NativeCodeGeneratorConfig {
         SourceSet sourceSet;
         private String[] sourceDirs;
         String[] includes = null;


### PR DESCRIPTION
groovy allows the access violation, however kotlin odes not.