### PR TITLE
chore: Remove deprecated fields and methods for v3

### DIFF
--- a/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/HostDetection.java
+++ b/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/HostDetection.java
@@ -39,41 +39,4 @@ public class HostDetection {
             architecture = Architecture.x86;
         }
     }
-
-    /**
-     * @deprecated Use {@link #os} as {@code SharedLibraryLoader.os == Os.Windows} instead.
-     */
-    @Deprecated
-    static public boolean isWindows = os == Os.Windows;
-    /**
-     * @deprecated Use {@link #os} as {@code SharedLibraryLoader.os == Os.Linux} instead.
-     */
-    @Deprecated
-    static public boolean isLinux = os == Os.Linux;
-    /**
-     * @deprecated Use {@link #os} as {@code SharedLibraryLoader.os == Os.MacOsX} instead.
-     */
-    @Deprecated
-    static public boolean isMac = os == Os.MacOsX;
-    /**
-     * @deprecated Use {@link #os} as {@code SharedLibraryLoader.os == Os.IOS} instead.
-     */
-    @Deprecated
-    static public boolean isIos = os == Os.IOS;
-    /**
-     * @deprecated Use {@link #os} as {@code SharedLibraryLoader.os == Os.Android} instead.
-     */
-    @Deprecated
-    static public boolean isAndroid = os == Os.Android;
-    /**
-     * @deprecated Use {@link #architecture} as {@code SharedLibraryLoader.architecture == Architecture.ARM} instead.
-     */
-    @Deprecated
-    static public boolean isARM = architecture == Architecture.ARM;
-    /**
-     * @deprecated Use {@link #bitness} as {@code SharedLibraryLoader.bitness == Architecture.Bitness._64} instead.
-     */
-    @Deprecated
-    static public boolean is64Bit = bitness == Architecture.Bitness._64;
-
 }

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -305,14 +305,6 @@ public class JnigenExtension {
                     + "`, excludes=`" + Arrays.toString(excludes) + "`]";
         }
 
-        /**
-         * This method is deprecated in favor of {@link NativeCodeGeneratorConfig#setSourceDirs(String[])}
-         */
-        @Deprecated
-        public void setSourceDir (String sourceDir) {
-            this.sourceDirs = new String[]{sourceDir};
-        }
-
         public void setSourceDirs (String[] sourceDirs) {
             this.sourceDirs = sourceDirs;
         }

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -217,29 +217,9 @@ public class BuildTarget {
 
     /**
      * Creates a new default BuildTarget for the given OS, using common default values.
-     *
-     * @deprecated Use {@link #newDefaultTarget(Os, Architecture.Bitness) newDefaultTarget} method.
-     */
-    @Deprecated
-    public static BuildTarget newDefaultTarget (Os osTarget, boolean is64Bit) {
-        return newDefaultTarget(osTarget, is64Bit, false);
-    }
-
-    /**
-     * Creates a new default BuildTarget for the given OS, using common default values.
      */
     public static BuildTarget newDefaultTarget (Os osTarget, Architecture.Bitness bitness) {
         return newDefaultTarget(osTarget, bitness, Architecture.x86);
-    }
-
-    /**
-     * Creates a new default BuildTarget for the given OS, using common default values.
-     *
-     * @deprecated Use {@link #newDefaultTarget(Os, Architecture.Bitness, Architecture) newDefaultTarget} method.
-     */
-    @Deprecated
-    public static BuildTarget newDefaultTarget (Os osTarget, boolean is64Bit, boolean isARM) {
-        return newDefaultTarget(osTarget, is64Bit ? Architecture.Bitness._64 : Architecture.Bitness._32, isARM ? Architecture.ARM : Architecture.x86);
     }
 
     public static BuildTarget newDefaultTarget (Os osTarget, Architecture.Bitness bitness, Architecture architecture) {


### PR DESCRIPTION
I think we want to remove them when we release v3 since it is a major release