### PR TITLE
Strip generics before parsing type

### DIFF
--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/parsing/RobustJavaMethodParser.java
@@ -155,9 +155,30 @@ public class RobustJavaMethodParser implements JavaMethodParser {
 		return new JavaMethod(className, name, isStatic, returnType, null, arguments, method.getBegin().get().line, method.getEnd().get().line);
 	}
 
+	public String removeGenerics(String type) {
+		StringBuilder result = new StringBuilder();
+		int bracketCount = 0;
+
+		for (char c : type.toCharArray()) {
+			if (c == '<') {
+				bracketCount++;
+				continue;
+			}
+			if (c == '>') {
+				bracketCount--;
+				continue;
+			}
+			if (bracketCount == 0) {
+				result.append(c);
+			}
+		}
+		return result.toString();
+	}
+
 	private ArgumentType getArgumentType (Parameter parameter) {
 		String[] typeTokens = parameter.getType().toString().split("\\.");
 		String type = typeTokens[typeTokens.length - 1];
+		type = removeGenerics(type);
 		int arrayDim = 0;
 		for (int i = 0; i < type.length(); i++) {
 			if (type.charAt(i) == '[') arrayDim++;


### PR DESCRIPTION
Currently jnigen fails if processing a type with generics.
As generics are erased at runtime anyway, we can just do it manually in jnigen for parsing purpose