### PR TITLE
Make flags args proper arrays

### DIFF
--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -72,10 +72,6 @@ public class BuildTarget {
      */
     public String cppCompiler = "g++";
     /**
-     * the command to use when archiving files. Usually ar, must not be null
-     */
-    public String archiver = "ar";
-    /**
      * prefix for the compiler (g++, gcc), useful for cross compilation, must not be null
      **/
     public String compilerPrefix = "";
@@ -86,23 +82,19 @@ public class BuildTarget {
     /**
      * the flags passed to the C compiler, must not be null
      **/
-    public String cFlags;
+    public String[] cFlags;
     /**
      * the flags passed to the C++ compiler, must not be null
      **/
-    public String cppFlags;
+    public String[] cppFlags;
     /**
      * the flags passed to the linker, must not be null
      **/
-    public String linkerFlags;
+    public String[] linkerFlags;
     /**
      * Pre linker flags for msvc, required separately during linking to provide compiler flags
      **/
-    public String msvcPreLinkerFlags;
-    /**
-     * the flags passed to the archiver, must not be null
-     **/
-    public String archiverFlags = "rcs";
+    public String[] msvcPreLinkerFlags;
     /**
      * the name of the generated build file for this target, defaults to "build-${target}(64)?.xml", must not be null
      **/
@@ -112,17 +104,9 @@ public class BuildTarget {
      **/
     public boolean excludeFromMasterBuildFile = false;
     /**
-     * Ant XML executed in a target before compilation
-     **/
-    public String preCompileTask;
-    /**
-     * Ant Xml executed in a target after compilation
-     **/
-    public String postCompileTask;
-    /**
      * the libraries to be linked to the output, specify via e.g. -ldinput -ldxguid etc.
      **/
-    public String libraries;
+    public String[] libraries;
     /**
      * The name used for folders for this specific target. Defaults to "${target}(64)"
      **/
@@ -160,7 +144,7 @@ public class BuildTarget {
     /**
      * Creates a new build target. See members of this class for a description of the parameters.
      */
-    public BuildTarget (Os targetOs, Architecture.Bitness bitness, String[] cIncludes, String[] cExcludes, String[] cppIncludes, String[] cppExcludes, String[] headerDirs, String compilerPrefix, String cFlags, String cppFlags, String linkerFlags, String msvcPreLinkerFlags) {
+    public BuildTarget (Os targetOs, Architecture.Bitness bitness, String[] cIncludes, String[] cExcludes, String[] cppIncludes, String[] cppExcludes, String[] headerDirs, String compilerPrefix, String[] cFlags, String[] cppFlags, String[] linkerFlags, String[] msvcPreLinkerFlags) {
         if (targetOs == null) throw new IllegalArgumentException("targetOs must not be null");
         if (cIncludes == null) cIncludes = new String[0];
         if (cExcludes == null) cExcludes = new String[0];
@@ -168,10 +152,10 @@ public class BuildTarget {
         if (cppExcludes == null) cppExcludes = new String[0];
         if (headerDirs == null) headerDirs = new String[0];
         if (compilerPrefix == null) compilerPrefix = "";
-        if (cFlags == null) cFlags = "";
-        if (cppFlags == null) cppFlags = "";
-        if (linkerFlags == null) linkerFlags = "";
-        if (msvcPreLinkerFlags == null) msvcPreLinkerFlags = "";
+        if (cFlags == null) cFlags = new String[0];
+        if (cppFlags == null) cppFlags = new String[0];
+        if (linkerFlags == null) linkerFlags = new String[0];
+        if (msvcPreLinkerFlags == null) msvcPreLinkerFlags = new String[0];
 
         this.os = targetOs;
         this.bitness = bitness;
@@ -185,7 +169,7 @@ public class BuildTarget {
         this.cppFlags = cppFlags;
         this.linkerFlags = linkerFlags;
         this.msvcPreLinkerFlags = msvcPreLinkerFlags;
-        this.libraries = "";
+        this.libraries = new String[0];
     }
 
     public String getBuildFilename () {
@@ -239,9 +223,9 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.x86 && bitness == Architecture.Bitness._32) {
                 // Windows x86 32-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "", "/O2 /W4 /fp:fast",
-                        "/O2 /W4 /fp:fast",
-                        "/DLL", "/MT");
+                        new String[0], new String[0], "", new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[]{"/DLL"}, new String[]{"/MT"});
                 target.cCompiler = "cl.exe";
                 target.cppCompiler = "cl.exe";
                 target.compilerABIType = abiType;
@@ -251,9 +235,9 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.x86 && bitness == Architecture.Bitness._64) {
                 // Windows x86 64-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "", "/O2 /W4 /fp:fast",
-                        "/O2 /W4 /fp:fast",
-                        "", "/MT");
+                        new String[0], new String[0], "", new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[0], new String[]{"/MT"});
                 target.compilerABIType = abiType;
                 target.cCompiler = "cl.exe";
                 target.cppCompiler = "cl.exe";
@@ -263,9 +247,9 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.ARM && bitness == Architecture.Bitness._32) {
                 // Windows ARM 32-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "", "/O2 /W4 /fp:fast",
-                        "/O2 /W4 /fp:fast",
-                        "", "/MT");
+                        new String[0], new String[0], "", new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[0], new String[]{"/MT"});
                 target.cCompiler = "cl.exe";
                 target.cppCompiler = "cl.exe";
                 target.architecture = Architecture.ARM;
@@ -276,9 +260,9 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.ARM && bitness == Architecture.Bitness._64) {
                 // Windows ARM 64-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "", "/O2 /W4 /fp:fast",
-                        "/O2 /W4 /fp:fast",
-                        "", "/MT");
+                        new String[0], new String[0], "", new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[]{"/O2", "/W4", "/fp:fast"},
+                        new String[0], new String[]{"/MT"});
                 target.cCompiler = "cl.exe";
                 target.cppCompiler = "cl.exe";
                 target.architecture = Architecture.ARM;
@@ -289,25 +273,25 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.x86 && bitness == Architecture.Bitness._32) {
                 // Windows x86 32-Bit
                 return new BuildTarget(Os.Windows, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "i686-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32",
-                        "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m32",
-                        "-Wl,--kill-at -shared -m32 -static -static-libgcc -static-libstdc++", null);
+                        new String[0], new String[0], "i686-w64-mingw32-", new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse2", "-fmessage-length=0", "-m32"},
+                        new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse2", "-fmessage-length=0", "-m32"},
+                        new String[] {"-Wl,--kill-at", "-shared", "-static", "-static-libgcc", "-static-libstdc++", "-m32"}, null);
             }
 
             if (osTarget == Os.Windows && architecture == Architecture.x86 && bitness == Architecture.Bitness._64) {
                 // Windows x86 64-Bit
                 return new BuildTarget(Os.Windows, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "x86_64-w64-mingw32-", "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
-                        "-c -Wall -O2 -mfpmath=sse -msse2 -fmessage-length=0 -m64",
-                        "-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++ -m64", null);
+                        new String[0], new String[0], "x86_64-w64-mingw32-", new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse2", "-fmessage-length=0", "-m64"},
+                        new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse2", "-fmessage-length=0", "-m64"},
+                        new String[] {"-Wl,--kill-at", "-shared", "-static", "-static-libgcc", "-static-libstdc++", "-m64"}, null);
             }
 
             if (osTarget == Os.Windows && architecture == Architecture.ARM && bitness == Architecture.Bitness._32) {
                 // Windows ARM 32-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "armv7-w64-mingw32-", "-c -Wall -O2 -fmessage-length=0",
-                        "-c -Wall -O2 -fmessage-length=0",
-                        "-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++", null);
+                        new String[0], new String[0], "armv7-w64-mingw32-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0"},
+                        new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0"},
+                        new String[] {"-Wl,--kill-at", "-shared", "-static", "-static-libgcc", "-static-libstdc++"}, null);
                 target.architecture = Architecture.ARM;
                 return target;
             }
@@ -315,9 +299,9 @@ public class BuildTarget {
             if (osTarget == Os.Windows && architecture == Architecture.ARM && bitness == Architecture.Bitness._64) {
                 // Windows ARM 64-Bit
                 BuildTarget target = new BuildTarget(Os.Windows, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                        new String[0], new String[0], "aarch64-w64-mingw32-", "-c -Wall -O2 -fmessage-length=0",
-                        "-c -Wall -O2 -fmessage-length=0",
-                        "-Wl,--kill-at -shared -static -static-libgcc -static-libstdc++", null);
+                        new String[0], new String[0], "aarch64-w64-mingw32-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0"},
+                        new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0"},
+                        new String[] {"-Wl,--kill-at", "-shared", "-static", "-static-libgcc", "-static-libstdc++"}, null);
                 target.architecture = Architecture.ARM;
                 return target;
             }
@@ -326,8 +310,8 @@ public class BuildTarget {
         if (osTarget == Os.Linux && architecture == Architecture.LOONGARCH && bitness == Architecture.Bitness._64) {
             // Linux LoongArch 64-Bit
             BuildTarget target = new BuildTarget(Os.Linux, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "loongarch64-unknown-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-                    "-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared", null);
+                    new String[0], new String[0], "loongarch64-unknown-linux-gnu-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"},
+                    new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"}, new String[] {"-shared"}, null);
             target.architecture = Architecture.LOONGARCH;
             return target;
         }
@@ -335,8 +319,8 @@ public class BuildTarget {
         if (osTarget == Os.Linux && architecture == Architecture.RISCV && bitness == Architecture.Bitness._32) {
             // Linux RISCV 32-Bit
             BuildTarget target = new BuildTarget(Os.Linux, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "riscv32-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-                    "-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared", null);
+                    new String[0], new String[0], "riscv32-linux-gnu-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"},
+                    new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"}, new String[] {"-shared"}, null);
             target.architecture = Architecture.RISCV;
             return target;
         }
@@ -344,8 +328,8 @@ public class BuildTarget {
         if (osTarget == Os.Linux && architecture == Architecture.RISCV && bitness == Architecture.Bitness._64) {
             // Linux RISCV 64-Bit
             BuildTarget target = new BuildTarget(Os.Linux, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "riscv64-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-                    "-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared", null);
+                    new String[0], new String[0], "riscv64-linux-gnu-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"},
+                    new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"}, new String[] {"-shared"}, null);
             target.architecture = Architecture.RISCV;
             return target;
         }
@@ -353,8 +337,8 @@ public class BuildTarget {
         if (osTarget == Os.Linux && architecture == Architecture.ARM && bitness == Architecture.Bitness._32) {
             // Linux ARM 32-Bit hardfloat
             BuildTarget target = new BuildTarget(Os.Linux, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "arm-linux-gnueabihf-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-                    "-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared", null);
+                    new String[0], new String[0], "arm-linux-gnueabihf-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"},
+                    new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"}, new String[] {"-shared"}, null);
             target.architecture = Architecture.ARM;
             return target;
         }
@@ -362,8 +346,8 @@ public class BuildTarget {
         if (osTarget == Os.Linux && architecture == Architecture.ARM && bitness == Architecture.Bitness._64) {
             // Linux ARM 64-Bit
             BuildTarget target = new BuildTarget(Os.Linux, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "aarch64-linux-gnu-", "-c -Wall -O2 -fmessage-length=0 -fPIC",
-                    "-c -Wall -O2 -fmessage-length=0 -fPIC", "-shared", null);
+                    new String[0], new String[0], "aarch64-linux-gnu-", new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"},
+                    new String[]{"-c", "-Wall", "-O2", "-fmessage-length=0", "-fPIC"}, new String[] {"-shared"}, null);
             target.architecture = Architecture.ARM;
             return target;
         }
@@ -371,15 +355,15 @@ public class BuildTarget {
         if (osTarget == Os.Linux && bitness == Architecture.Bitness._32) {
             // Linux 32-Bit
             return new BuildTarget(Os.Linux, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC",
-                    "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m32 -fPIC", "-shared -m32", null);
+                    new String[0], new String[0], "", new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse", "-fmessage-length=0", "-fPIC", "-m32"},
+                    new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse", "-fmessage-length=0", "-fPIC", "-m32"}, new String[] {"-shared", "-m32"}, null);
         }
 
         if (osTarget == Os.Linux && bitness == Architecture.Bitness._64) {
             // Linux 64-Bit
             return new BuildTarget(Os.Linux, Architecture.Bitness._64, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "", "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC",
-                    "-c -Wall -O2 -mfpmath=sse -msse -fmessage-length=0 -m64 -fPIC", "-shared -m64", null);
+                    new String[0], new String[0], "", new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse", "-fmessage-length=0", "-fPIC", "-m64"},
+                    new String[]{"-c", "-Wall", "-O2", "-mfpmath=sse", "-msse", "-fmessage-length=0", "-fPIC", "-m64"}, new String[] {"-shared", "-m64"}, null);
         }
 
         if (osTarget == Os.MacOsX && bitness == Architecture.Bitness._32) {
@@ -390,9 +374,9 @@ public class BuildTarget {
             // Mac OS aarch64
             BuildTarget mac = new BuildTarget(Os.MacOsX, Architecture.Bitness._64, new String[]{""}, new String[0],
                     new String[]{""}, new String[0], new String[0], "",
-                    "-c -Wall -O2 -arch arm64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-                    "-c -Wall -O2 -arch arm64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-                    "-shared -arch arm64 -mmacosx-version-min=10.7 -stdlib=libc++", null);
+                    new String[] {"-c", "-Wall", "-O2", "-arch", "arm64", "-DFIXED_POINT", "-fmessage-length=0", "-fPIC", "-mmacosx-version-min=10.7", "-stdlib=libc++"},
+                    new String[] {"-c", "-Wall", "-O2", "-arch", "arm64", "-DFIXED_POINT", "-fmessage-length=0", "-fPIC", "-mmacosx-version-min=10.7", "-stdlib=libc++"},
+                    new String[] {"-shared", "-arch", "arm64", "-mmacosx-version-min=10.7", "-stdlib=libc++"}, null);
             mac.cCompiler = "clang";
             mac.cppCompiler = "clang++";
             mac.architecture = Architecture.ARM;
@@ -403,9 +387,9 @@ public class BuildTarget {
             // Mac OS x86_64
             BuildTarget mac = new BuildTarget(Os.MacOsX, Architecture.Bitness._64, new String[]{""}, new String[0],
                     new String[]{""}, new String[0], new String[0], "",
-                    "-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-                    "-c -Wall -O2 -arch x86_64 -DFIXED_POINT -fmessage-length=0 -fPIC -mmacosx-version-min=10.7 -stdlib=libc++",
-                    "-shared -arch x86_64 -mmacosx-version-min=10.7 -stdlib=libc++", null);
+                    new String[] {"-c", "-Wall", "-O2", "-arch", "x86_64", "-DFIXED_POINT", "-fmessage-length=0", "-fPIC", "-mmacosx-version-min=10.7", "-stdlib=libc++"},
+                    new String[] {"-c", "-Wall", "-O2", "-arch", "x86_64", "-DFIXED_POINT", "-fmessage-length=0", "-fPIC", "-mmacosx-version-min=10.7", "-stdlib=libc++"},
+                    new String[] {"-shared", "-arch", "x86_64", "-mmacosx-version-min=10.7", "-stdlib=libc++"}, null);
             mac.cCompiler = "clang";
             mac.cppCompiler = "clang++";
             return mac;
@@ -413,16 +397,16 @@ public class BuildTarget {
 
         if (osTarget == Os.Android) {
             BuildTarget android = new BuildTarget(Os.Android, Architecture.Bitness._32, new String[]{""}, new String[0],
-                    new String[]{""}, new String[0], new String[0], "", "-O2 -Wall -D__ANDROID__", "-O2 -Wall -D__ANDROID__",
-                    "-lm -Wl,-z,max-page-size=0x4000", null);
+                    new String[]{""}, new String[0], new String[0], "", new String[] {"-O2", "-Wall", "-D__ANDROID__"}, new String[] {"-O2", "-Wall", "-D__ANDROID__"},
+                    new String[] {"-lm", "-Wl,-z,max-page-size=0x4000"}, null);
             return android;
         }
 
         if (osTarget == Os.IOS) {
             // iOS, x86_64 simulator, armv7, and arm64 compiled to fat static lib
             BuildTarget ios = new BuildTarget(Os.IOS, bitness, new String[]{""}, new String[0], new String[]{""},
-                    new String[0], new String[0], "", "-c -Wall -O2 -stdlib=libc++", "-c -Wall -O2 -stdlib=libc++",
-                    "-shared -stdlib=libc++", null);
+                    new String[0], new String[0], "", new String[] {"-c", "-Wall", "-O2", "-stdlib=libc++"}, new String[] {"-c", "-Wall", "-O2", "-stdlib=libc++"},
+                    new String[] {"-shared", "-stdlib=libc++"}, null);
             ios.cCompiler = "clang";
             ios.cppCompiler = "clang++";
             ios.targetType = targetType;

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -125,7 +125,10 @@ public class BuildTarget {
      * Extra lines which will be added to Android's Application.mk
      */
     public String[] androidApplicationMk = {};
-
+    /**
+     * Extra lines which will be added to Android's Android.mk `BUILD_SHARED_LIBRARY` module
+     */
+    public String[] androidAndroidMkSharedLibModule = {};
     /**
      * Is the target a simulator
      */

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/AndroidToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/AndroidToolchain.java
@@ -102,6 +102,7 @@ public class AndroidToolchain extends BaseToolchain {
         template = template.replace("%linkerFlags%", argsArrayToString(target.linkerFlags));
         template = template.replace("%libraries%", argsArrayToString(target.libraries));
         template = template.replace("%srcFiles%", srcFiles);
+        template = template.replace("%extraSharedLibModule%", String.join("\n", target.androidAndroidMkSharedLibModule));
         for (String extra : target.androidAndroidMk)
             template += "\n" + extra;
 

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/AndroidToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/AndroidToolchain.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class AndroidToolchain extends BaseToolchain {
 
@@ -16,6 +18,12 @@ public class AndroidToolchain extends BaseToolchain {
     private static final Logger logger = LoggerFactory.getLogger(AndroidToolchain.class);
 
     private File ndkExecutable;
+
+    private String argsArrayToString(String[] args) {
+        return Arrays.stream(args)
+                .map(s -> "\"" + s + "\"")
+                .collect(Collectors.joining(" "));
+    }
 
     @Override
     public void checkForTools () {
@@ -89,10 +97,10 @@ public class AndroidToolchain extends BaseToolchain {
 
         template = template.replace("%sharedLibName%", config.sharedLibName);
         template = template.replace("%headerDirs%", headerDirs);
-        template = template.replace("%cFlags%", target.cFlags);
-        template = template.replace("%cppFlags%", target.cppFlags);
-        template = template.replace("%linkerFlags%", target.linkerFlags);
-        template = template.replace("%libraries%", target.libraries);
+        template = template.replace("%cFlags%", argsArrayToString(target.cFlags));
+        template = template.replace("%cppFlags%", argsArrayToString(target.cppFlags));
+        template = template.replace("%linkerFlags%", argsArrayToString(target.linkerFlags));
+        template = template.replace("%libraries%", argsArrayToString(target.libraries));
         template = template.replace("%srcFiles%", srcFiles);
         for (String extra : target.androidAndroidMk)
             template += "\n" + extra;

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/GNUToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/GNUToolchain.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -56,7 +57,7 @@ public class GNUToolchain extends BaseToolchain {
         }
 
         List<String> args = new ArrayList<>();
-        args.addAll(stringFlagsToArgs(target.cFlags));
+        args.addAll(Arrays.asList(target.cFlags));
 
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/"));
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/" + target.os.getJniPlatform()));
@@ -92,7 +93,7 @@ public class GNUToolchain extends BaseToolchain {
         }
 
         List<String> args = new ArrayList<>();
-        args.addAll(stringFlagsToArgs(target.cppFlags));
+        args.addAll(Arrays.asList(target.cppFlags));
 
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/"));
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/" + target.os.getJniPlatform()));
@@ -147,15 +148,14 @@ public class GNUToolchain extends BaseToolchain {
 
         List<String> args = new ArrayList<>();
 
-        args.addAll(stringFlagsToArgs(target.linkerFlags));
+        args.addAll(Arrays.asList(target.linkerFlags));
         args.add("-o");
         args.add(targetLibFile.getAbsolutePath());
         for (File objFile : objFiles) {
             args.add(objFile.getAbsolutePath());
         }
-        if (!target.libraries.isEmpty()) {
-            args.addAll(stringFlagsToArgs(target.libraries));
-        }
+
+        args.addAll(Arrays.asList(target.libraries));
 
         ToolchainExecutor.execute(linkerExecutable, config.buildDir.file(), args, createToolChainCallback("Link"));
     }

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/IOSToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/IOSToolchain.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -80,7 +81,7 @@ public class IOSToolchain extends BaseToolchain {
         String iosVesion = target.targetType == TargetType.DEVICE ? "-miphoneos-version-min" : "-mios-simulator-version-min";
         args.add(iosVesion + "=" + config.robovmBuildConfig.minIOSVersion);
 
-        args.addAll(stringFlagsToArgs(target.cFlags));
+        args.addAll(Arrays.asList(target.cFlags));
 
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers"));
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/" + target.os.getJniPlatform()));
@@ -132,7 +133,7 @@ public class IOSToolchain extends BaseToolchain {
         String iosVesion = target.targetType == TargetType.DEVICE ? "-miphoneos-version-min" : "-mios-simulator-version-min";
         args.add(iosVesion + "=" + config.robovmBuildConfig.minIOSVersion);
 
-        args.addAll(stringFlagsToArgs(target.cppFlags));
+        args.addAll(Arrays.asList(target.cppFlags));
 
 
         args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers"));
@@ -202,7 +203,7 @@ public class IOSToolchain extends BaseToolchain {
         String iosVesion = target.targetType == TargetType.DEVICE ? "-miphoneos-version-min" : "-mios-simulator-version-min";
         args.add(iosVesion + "=" + config.robovmBuildConfig.minIOSVersion);
 
-        args.addAll(stringFlagsToArgs(target.linkerFlags));
+        args.addAll(Arrays.asList(target.linkerFlags));
         args.add("-install_name");
         args.add("@rpath/" + config.sharedLibName + ".framework/" + config.sharedLibName);
 
@@ -211,9 +212,7 @@ public class IOSToolchain extends BaseToolchain {
         for (File objFile : objFiles) {
             args.add(objFile.getAbsolutePath());
         }
-        if (!target.libraries.isEmpty()) {
-            args.addAll(stringFlagsToArgs(target.libraries));
-        }
+        args.addAll(Arrays.asList(target.libraries));
 
         ToolchainExecutor.execute(linkerExecutable, config.buildDir.file(), args, createToolChainCallback("Link"));
     }

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/MSVCToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/MSVCToolchain.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -198,7 +199,7 @@ public class MSVCToolchain extends BaseToolchain {
         }
 
         List<String> args = new ArrayList<>();
-        args.addAll(stringFlagsToArgs(target.cFlags));
+        args.addAll(Arrays.asList(target.cFlags));
         for (String msvcIncludeDirectory : msvcIncludeDirectories) {
             args.add("/I" + msvcIncludeDirectory);
         }
@@ -236,7 +237,7 @@ public class MSVCToolchain extends BaseToolchain {
         }
 
         List<String> args = new ArrayList<>();
-        args.addAll(stringFlagsToArgs(target.cppFlags));
+        args.addAll(Arrays.asList(target.cppFlags));
         for (String msvcIncludeDirectory : msvcIncludeDirectories) {
             args.add("/I" + msvcIncludeDirectory);
         }
@@ -300,9 +301,7 @@ public class MSVCToolchain extends BaseToolchain {
             args.add("/Zi");
         }
 
-        if (!target.msvcPreLinkerFlags.isEmpty()) {
-            args.addAll(stringFlagsToArgs(target.msvcPreLinkerFlags));
-        }
+        args.addAll(Arrays.asList(target.msvcPreLinkerFlags));
 
         args.add("/Fe" + targetLibFile.getName());
         for (File objFile : objFiles) {
@@ -321,10 +320,8 @@ public class MSVCToolchain extends BaseToolchain {
         for (String msvcLibDirectory : msvcLibDirectories) {
             args.add("/LIBPATH:" + msvcLibDirectory);
         }
-        args.addAll(stringFlagsToArgs(target.linkerFlags));
-        if (!target.libraries.isEmpty()) {
-            args.addAll(stringFlagsToArgs(target.libraries));
-        }
+        args.addAll(Arrays.asList(target.linkerFlags));
+        args.addAll(Arrays.asList(target.libraries));
 
         logger.info("Linking Target {}", target);
 

--- a/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/Android.mk.template
+++ b/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/Android.mk.template
@@ -11,4 +11,7 @@ LOCAL_LDLIBS := %libraries%
 LOCAL_ARM_MODE  := arm
 
 LOCAL_SRC_FILES := %srcFiles%
+
+%extraSharedLibModule%
+
 include $(BUILD_SHARED_LIBRARY)

--- a/gdx-jnigen-generator-test/build.gradle
+++ b/gdx-jnigen-generator-test/build.gradle
@@ -44,8 +44,8 @@ jnigen {
     }
 
     all {
-        cFlags += " -std=c11 -fexceptions "
-        cppFlags += " -std=c++11 -fexceptions "
+        cFlags += ["-std=c11", "-fexceptions"]
+        cppFlags += ["-std=c++11", "-fexceptions"]
 
         headerDirs += ["src/test/resources/"]
         cppIncludes += ["src/test/resources/*.cpp"]
@@ -80,8 +80,8 @@ jnigen {
     addWindows(x64, x86)
     //add(Windows, x64, ARM)
     addAndroid() {
-        androidApplicationMk += "APP_STL := c++_shared"
-        linkerFlags += " -stdlib=libc++\n"
+        androidApplicationMk += ["APP_STL := c++_shared"]
+        linkerFlags += ["-stdlib=libc++"]
     }
     addIOS()
 }

--- a/gdx-jnigen-runtime/build.gradle
+++ b/gdx-jnigen-runtime/build.gradle
@@ -205,7 +205,8 @@ jnigen {
     addAndroid() {
         libraries = ""
         androidApplicationMk += ["APP_PLATFORM := android-19", "APP_STRIP_MODE := none", "APP_STL := c++_shared"]
-        linkerFlags += ["-stdlib=libc++", "LOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"]
+        linkerFlags += ["-stdlib=libc++"]
+        androidApplicationMkSharedLibModule += ["LOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"]
         androidAndroidMk += [
                 "include \$(CLEAR_VARS)",
                 "LOCAL_MODULE := static_libffi",

--- a/gdx-jnigen-runtime/build.gradle
+++ b/gdx-jnigen-runtime/build.gradle
@@ -188,8 +188,8 @@ jnigen {
         headerDirs += ["build/libffi-build/${combined}/include/", "src/main/native"]
         cppIncludes += ["src/main/native/*.cpp"]
         cIncludes += ["src/main/native/*.c"]
-        cFlags += " -std=c11 -fexceptions "
-        cppFlags += " -std=c++11 -fexceptions "
+        cFlags += ["-std=c11", "-fexceptions"]
+        cppFlags += ["-std=c++11", "-fexceptions"]
         libraries += file("build/libffi-build/${combined}/lib/libffi.a").absolutePath
     }
 
@@ -204,8 +204,8 @@ jnigen {
     //add(Windows, x64, ARM)
     addAndroid() {
         libraries = ""
-        androidApplicationMk += "APP_PLATFORM := android-19\nAPP_STRIP_MODE := none\nAPP_STL := c++_shared"
-        linkerFlags += " -stdlib=libc++\nLOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"
+        androidApplicationMk += ["APP_PLATFORM := android-19", "APP_STRIP_MODE := none", "APP_STL := c++_shared"]
+        linkerFlags += ["-stdlib=libc++", "LOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"]
         androidAndroidMk += [
                 "include \$(CLEAR_VARS)",
                 "LOCAL_MODULE := static_libffi",

--- a/gdx-jnigen-runtime/build.gradle
+++ b/gdx-jnigen-runtime/build.gradle
@@ -206,7 +206,7 @@ jnigen {
         libraries = ""
         androidApplicationMk += ["APP_PLATFORM := android-19", "APP_STRIP_MODE := none", "APP_STL := c++_shared"]
         linkerFlags += ["-stdlib=libc++"]
-        androidApplicationMkSharedLibModule += ["LOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"]
+        androidAndroidMkSharedLibModule += ["LOCAL_WHOLE_STATIC_LIBRARIES := static_libffi"]
         androidAndroidMk += [
                 "include \$(CLEAR_VARS)",
                 "LOCAL_MODULE := static_libffi",


### PR DESCRIPTION
This PR converts the remaining fields that are Strings and handle command line args, to proper `String[]`. This allows to use proper white spaces inside them.

Two main issues:
1. Kotlin/Gradle DSL work for `arrayType += stringType` automatically, leading to this change not throwing compiler errors.
2. The hack described here https://github.com/libgdx/gdx-jnigen/issues/72 doesn't work anymore, due to android arg escape. A proper fix should be also implemented for the issue.