### PR TITLE
Optimize GC handling

### DIFF
--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/ClassNameConstants.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/ClassNameConstants.java
@@ -19,6 +19,5 @@ public final class ClassNameConstants {
     public static final String FLOATPOINTER_CLASS = "com.badlogic.gdx.jnigen.runtime.pointer.FloatPointer";
     public static final String POINTERPOINTER_CLASS = "com.badlogic.gdx.jnigen.runtime.pointer.PointerPointer";
     public static final String VOIDPOINTER_CLASS = "com.badlogic.gdx.jnigen.runtime.pointer.VoidPointer";
-
-
+    public static final String POINTING_CLASS = "com.badlogic.gdx.jnigen.runtime.pointer.Pointing";
 }

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Manager.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Manager.java
@@ -194,7 +194,7 @@ public class Manager {
         String lineToPatch = Arrays.stream(classString.split("\r\n|\n"))
                 .filter(line -> line.contains(methodString)).findFirst().orElse(null);
         if (lineToPatch == null)
-            throw new IllegalArgumentException("Failed to find native method: " + method.toString() + " in " + classString);
+            throw new IllegalArgumentException("Failed to find native method: " + method + " in " + classString);
 
         String offset = lineToPatch.replace(lineToPatch.trim(), "");
         String newLine = lineToPatch + "/*\n";

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
@@ -81,6 +81,7 @@ public class StackElementType implements MappedType, WritableClass {
         cuPublic.addImport(ClassNameConstants.CHANDLER_CLASS);
         cuPublic.addImport(isStruct ? ClassNameConstants.STRUCT_CLASS : ClassNameConstants.UNION_CLASS);
         cuPublic.addImport(ClassNameConstants.STACKELEMENTPOINTER_CLASS);
+        cuPublic.addImport(ClassNameConstants.POINTING_CLASS);
 
         if (comment != null) {
             toWriteToPublic.setJavadocComment(comment);
@@ -115,7 +116,7 @@ public class StackElementType implements MappedType, WritableClass {
                 .createBody().addStatement("return __ffi_type;");
 
         toWriteToPublic.addMethod("asPointer", Keyword.PUBLIC).setType(structPointerRef)
-                .createBody().addStatement("return new " + structPointerRef + "(getPointer(), getsGCFreed());");
+                .createBody().addStatement("return new " + structPointerRef + "(getPointer(), false, this);");
 
         // Fields
         int index = 0;
@@ -200,6 +201,14 @@ public class StackElementType implements MappedType, WritableClass {
         BlockStmt body = new BlockStmt();
         body.addStatement("super(pointer, freeOnGC);");
         pointerConstructor.setBody(body);
+
+
+        ConstructorDeclaration pointerAndParentTakingConstructor = pointerClass.addConstructor(Keyword.PUBLIC);
+        pointerAndParentTakingConstructor.addParameter(long.class, "pointer");
+        pointerAndParentTakingConstructor.addParameter(boolean.class, "freeOnGC");
+        pointerAndParentTakingConstructor.addParameter("Pointing", "parent");
+        pointerAndParentTakingConstructor.getBody().addStatement("super(pointer, freeOnGC);")
+                .addStatement("setParent(parent);");
 
         pointerClass.addConstructor(Keyword.PUBLIC).getBody().addStatement("this(1, true, true);");
 

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
@@ -33,7 +33,7 @@ public class StackElementType implements MappedType, WritableClass {
     private final List<TypeDefinition> children = new ArrayList<>();
 
     // TODO: Conceptionally, this belongs into TypeDefinition
-    private boolean isStruct;
+    private final boolean isStruct;
     private final List<StackElementField> fields = new ArrayList<>();
     private final String pointerName;
     private final String javaTypeName;

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousClosure.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousClosure.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.gdx.jnigen.runtime.closure.ClosureObject;
 import com.badlogic.gdx.jnigen.runtime.closure.Closure;
@@ -38,7 +39,7 @@ public final class AnonymousClosure extends Struct {
     }
 
     public AnonymousClosure.AnonymousClosurePointer asPointer() {
-        return new AnonymousClosure.AnonymousClosurePointer(getPointer(), getsGCFreed());
+        return new AnonymousClosure.AnonymousClosurePointer(getPointer(), false, this);
     }
 
     /**
@@ -67,6 +68,11 @@ public final class AnonymousClosure extends Struct {
 
         public AnonymousClosurePointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousClosurePointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousClosurePointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructField.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructField.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.jnigen.generated.structs.AnonymousStructField.inner;
 
@@ -34,7 +35,7 @@ public final class AnonymousStructField extends Struct {
     }
 
     public AnonymousStructField.AnonymousStructFieldPointer asPointer() {
-        return new AnonymousStructField.AnonymousStructFieldPointer(getPointer(), getsGCFreed());
+        return new AnonymousStructField.AnonymousStructFieldPointer(getPointer(), false, this);
     }
 
     public inner inner() {
@@ -57,6 +58,11 @@ public final class AnonymousStructField extends Struct {
 
         public AnonymousStructFieldPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructFieldPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructFieldPointer() {
@@ -112,7 +118,7 @@ public final class AnonymousStructField extends Struct {
         }
 
         public inner.innerPointer asPointer() {
-            return new inner.innerPointer(getPointer(), getsGCFreed());
+            return new inner.innerPointer(getPointer(), false, this);
         }
 
         /**
@@ -141,6 +147,11 @@ public final class AnonymousStructField extends Struct {
 
             public innerPointer(long pointer, boolean freeOnGC) {
                 super(pointer, freeOnGC);
+            }
+
+            public innerPointer(long pointer, boolean freeOnGC, Pointing parent) {
+                super(pointer, freeOnGC);
+                setParent(parent);
             }
 
             public innerPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructFieldArray.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructFieldArray.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.jnigen.generated.structs.AnonymousStructFieldArray.inner;
 
@@ -34,7 +35,7 @@ public final class AnonymousStructFieldArray extends Struct {
     }
 
     public AnonymousStructFieldArray.AnonymousStructFieldArrayPointer asPointer() {
-        return new AnonymousStructFieldArray.AnonymousStructFieldArrayPointer(getPointer(), getsGCFreed());
+        return new AnonymousStructFieldArray.AnonymousStructFieldArrayPointer(getPointer(), false, this);
     }
 
     public inner.innerPointer inner() {
@@ -57,6 +58,11 @@ public final class AnonymousStructFieldArray extends Struct {
 
         public AnonymousStructFieldArrayPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructFieldArrayPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructFieldArrayPointer() {
@@ -109,7 +115,7 @@ public final class AnonymousStructFieldArray extends Struct {
         }
 
         public inner.innerPointer asPointer() {
-            return new inner.innerPointer(getPointer(), getsGCFreed());
+            return new inner.innerPointer(getPointer(), false, this);
         }
 
         public int intValue() {
@@ -132,6 +138,11 @@ public final class AnonymousStructFieldArray extends Struct {
 
             public innerPointer(long pointer, boolean freeOnGC) {
                 super(pointer, freeOnGC);
+            }
+
+            public innerPointer(long pointer, boolean freeOnGC, Pointing parent) {
+                super(pointer, freeOnGC);
+                setParent(parent);
             }
 
             public innerPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoField.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoField.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 /**
@@ -36,7 +37,7 @@ public final class AnonymousStructNoField extends Struct {
     }
 
     public AnonymousStructNoField.AnonymousStructNoFieldPointer asPointer() {
-        return new AnonymousStructNoField.AnonymousStructNoFieldPointer(getPointer(), getsGCFreed());
+        return new AnonymousStructNoField.AnonymousStructNoFieldPointer(getPointer(), false, this);
     }
 
     public int intValue() {
@@ -67,6 +68,11 @@ public final class AnonymousStructNoField extends Struct {
 
         public AnonymousStructNoFieldPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructNoFieldPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructNoFieldPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldConsecutive.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldConsecutive.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 public final class AnonymousStructNoFieldConsecutive extends Struct {
@@ -33,7 +34,7 @@ public final class AnonymousStructNoFieldConsecutive extends Struct {
     }
 
     public AnonymousStructNoFieldConsecutive.AnonymousStructNoFieldConsecutivePointer asPointer() {
-        return new AnonymousStructNoFieldConsecutive.AnonymousStructNoFieldConsecutivePointer(getPointer(), getsGCFreed());
+        return new AnonymousStructNoFieldConsecutive.AnonymousStructNoFieldConsecutivePointer(getPointer(), false, this);
     }
 
     public int externalValue() {
@@ -80,6 +81,11 @@ public final class AnonymousStructNoFieldConsecutive extends Struct {
 
         public AnonymousStructNoFieldConsecutivePointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructNoFieldConsecutivePointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructNoFieldConsecutivePointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldEnd.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldEnd.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 public final class AnonymousStructNoFieldEnd extends Struct {
@@ -33,7 +34,7 @@ public final class AnonymousStructNoFieldEnd extends Struct {
     }
 
     public AnonymousStructNoFieldEnd.AnonymousStructNoFieldEndPointer asPointer() {
-        return new AnonymousStructNoFieldEnd.AnonymousStructNoFieldEndPointer(getPointer(), getsGCFreed());
+        return new AnonymousStructNoFieldEnd.AnonymousStructNoFieldEndPointer(getPointer(), false, this);
     }
 
     public int externalValue() {
@@ -70,6 +71,11 @@ public final class AnonymousStructNoFieldEnd extends Struct {
 
         public AnonymousStructNoFieldEndPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructNoFieldEndPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructNoFieldEndPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldNested.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/AnonymousStructNoFieldNested.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 public final class AnonymousStructNoFieldNested extends Struct {
@@ -33,7 +34,7 @@ public final class AnonymousStructNoFieldNested extends Struct {
     }
 
     public AnonymousStructNoFieldNested.AnonymousStructNoFieldNestedPointer asPointer() {
-        return new AnonymousStructNoFieldNested.AnonymousStructNoFieldNestedPointer(getPointer(), getsGCFreed());
+        return new AnonymousStructNoFieldNested.AnonymousStructNoFieldNestedPointer(getPointer(), false, this);
     }
 
     public int intValue1() {
@@ -64,6 +65,11 @@ public final class AnonymousStructNoFieldNested extends Struct {
 
         public AnonymousStructNoFieldNestedPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public AnonymousStructNoFieldNestedPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public AnonymousStructNoFieldNestedPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/GlobalArg.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/GlobalArg.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Union;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.gdx.jnigen.runtime.pointer.CSizedIntPointer;
 import com.badlogic.gdx.jnigen.runtime.pointer.PointerPointer;
@@ -40,7 +41,7 @@ public final class GlobalArg extends Union {
     }
 
     public GlobalArg.GlobalArgPointer asPointer() {
-        return new GlobalArg.GlobalArgPointer(getPointer(), getsGCFreed());
+        return new GlobalArg.GlobalArgPointer(getPointer(), false, this);
     }
 
     public long longVal() {
@@ -173,6 +174,11 @@ public final class GlobalArg extends Union {
             super(pointer, freeOnGC);
         }
 
+        public GlobalArgPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
+        }
+
         public GlobalArgPointer() {
             this(1, true, true);
         }
@@ -223,7 +229,7 @@ public final class GlobalArg extends Union {
         }
 
         public allArgs.allArgsPointer asPointer() {
-            return new allArgs.allArgsPointer(getPointer(), getsGCFreed());
+            return new allArgs.allArgsPointer(getPointer(), false, this);
         }
 
         public long arg1() {
@@ -294,6 +300,11 @@ public final class GlobalArg extends Union {
 
             public allArgsPointer(long pointer, boolean freeOnGC) {
                 super(pointer, freeOnGC);
+            }
+
+            public allArgsPointer(long pointer, boolean freeOnGC, Pointing parent) {
+                super(pointer, freeOnGC);
+                setParent(parent);
             }
 
             public allArgsPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/SpecialStruct.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/SpecialStruct.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.gdx.jnigen.runtime.pointer.FloatPointer;
 import com.badlogic.gdx.jnigen.runtime.pointer.CSizedIntPointer;
@@ -38,7 +39,7 @@ public final class SpecialStruct extends Struct {
     }
 
     public SpecialStruct.SpecialStructPointer asPointer() {
-        return new SpecialStruct.SpecialStructPointer(getPointer(), getsGCFreed());
+        return new SpecialStruct.SpecialStructPointer(getPointer(), false, this);
     }
 
     public FloatPointer floatPtrField() {
@@ -69,6 +70,11 @@ public final class SpecialStruct extends Struct {
 
         public SpecialStructPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public SpecialStructPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public SpecialStructPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/TestStruct.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/TestStruct.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 /**
@@ -36,7 +37,7 @@ public final class TestStruct extends Struct {
     }
 
     public TestStruct.TestStructPointer asPointer() {
-        return new TestStruct.TestStructPointer(getPointer(), getsGCFreed());
+        return new TestStruct.TestStructPointer(getPointer(), false, this);
     }
 
     /**
@@ -99,6 +100,11 @@ public final class TestStruct extends Struct {
 
         public TestStructPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public TestStructPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public TestStructPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/TestUnion.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/TestUnion.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Union;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 import com.badlogic.gdx.jnigen.runtime.pointer.CSizedIntPointer;
 import com.badlogic.jnigen.generated.structs.TestStruct;
@@ -38,7 +39,7 @@ public final class TestUnion extends Union {
     }
 
     public TestUnion.TestUnionPointer asPointer() {
-        return new TestUnion.TestUnionPointer(getPointer(), getsGCFreed());
+        return new TestUnion.TestUnionPointer(getPointer(), false, this);
     }
 
     public long uintType() {
@@ -73,6 +74,11 @@ public final class TestUnion extends Union {
 
         public TestUnionPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public TestUnionPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public TestUnionPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/forwardDeclStruct.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/generated/structs/forwardDeclStruct.java
@@ -3,6 +3,7 @@ package com.badlogic.jnigen.generated.structs;
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.pointer.Struct;
 import com.badlogic.gdx.jnigen.runtime.pointer.StackElementPointer;
+import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 import com.badlogic.jnigen.generated.FFITypes;
 
 public final class forwardDeclStruct extends Struct {
@@ -33,13 +34,18 @@ public final class forwardDeclStruct extends Struct {
     }
 
     public forwardDeclStruct.forwardDeclStructPointer asPointer() {
-        return new forwardDeclStruct.forwardDeclStructPointer(getPointer(), getsGCFreed());
+        return new forwardDeclStruct.forwardDeclStructPointer(getPointer(), false, this);
     }
 
     public static final class forwardDeclStructPointer extends StackElementPointer<forwardDeclStruct> {
 
         public forwardDeclStructPointer(long pointer, boolean freeOnGC) {
             super(pointer, freeOnGC);
+        }
+
+        public forwardDeclStructPointer(long pointer, boolean freeOnGC, Pointing parent) {
+            super(pointer, freeOnGC);
+            setParent(parent);
         }
 
         public forwardDeclStructPointer() {

--- a/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/tests/GCTests.java
+++ b/gdx-jnigen-generator-test/src/test/java/com/badlogic/jnigen/tests/GCTests.java
@@ -30,9 +30,10 @@ public class GCTests extends BaseTest {
     public void testPointingNoDoubleReleased() {
         assertEquals(0, GCHandler.nativeObjectCount());
         Pointing pointing = new Pointing(0, true, true);
-        Pointing samePointer = new Pointing(pointing.getPointer(), true);
+        Pointing samePointer = new Pointing(pointing.getPointer(), false);
+        samePointer.setParent(pointing);
         assertEquals(pointing.getPointer(), samePointer.getPointer());
-        assertEquals(2, GCHandler.nativeObjectCount());
+        assertEquals(1, GCHandler.nativeObjectCount());
         WeakReference<Pointing> toCheckGC1 = new WeakReference<>(pointing);
         WeakReference<Pointing> toCheckGC2 = new WeakReference<>(samePointer);
         pointing = null;
@@ -51,6 +52,7 @@ public class GCTests extends BaseTest {
         assertEquals(0, GCHandler.nativeObjectCount());
         Pointing pointing = new Pointing(1, true, true);
         Pointing manually = new Pointing(pointing.getPointer(), false);
+        manually.setParent(pointing);
         assertThrows(IllegalStateException.class, manually::free);
     }
 }

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/ffi/ClosureDecoder.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/ffi/ClosureDecoder.java
@@ -7,17 +7,15 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public final class ClosureInfo<T extends Closure> {
+public final class ClosureDecoder<T extends Closure> {
 
-    private final long cif;
     private final T toCallOn;
 
     private final JavaTypeWrapper[] cachedWrappers;
     private final JavaTypeWrapper cachedReturnWrapper;
     private final AtomicBoolean cacheLock = new AtomicBoolean(false);
 
-    public ClosureInfo(long cif, T toCallOn) {
-        this.cif = cif;
+    public ClosureDecoder(T toCallOn) {
         this.toCallOn = toCallOn;
         CTypeInfo[] functionSignature = toCallOn.functionSignature();
         int parameterLength = functionSignature.length - 1;

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/GCHandler.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/GCHandler.java
@@ -13,6 +13,7 @@ public class GCHandler {
     private static final ReferenceList referenceList = new ReferenceList();
 
     private static final Thread RELEASER = new Thread() {
+        @SuppressWarnings("InfiniteLoopStatement")
         @Override
         public void run() {
             while (true) {

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/PointingPhantomReference.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/PointingPhantomReference.java
@@ -1,15 +1,36 @@
 package com.badlogic.gdx.jnigen.runtime.gc;
 
+import com.badlogic.gdx.jnigen.runtime.gc.ReferenceList.ReferenceListNode;
 import com.badlogic.gdx.jnigen.runtime.pointer.Pointing;
 
 import java.lang.ref.PhantomReference;
 
-public class PointingPhantomReference extends PhantomReference<Object> {
+public final class PointingPhantomReference extends PhantomReference<Pointing> {
 
     private final long pointer;
-    public PointingPhantomReference(Object referent, long pointer) {
+    private ReferenceListNode node;
+    private int position;
+
+
+    public PointingPhantomReference(Pointing referent) {
         super(referent, GCHandler.REFERENCE_QUEUE);
-        this.pointer = pointer;
+        this.pointer = referent.getPointer();
+    }
+
+    public void setNode(ReferenceListNode node) {
+        this.node = node;
+    }
+
+    public ReferenceListNode getNode() {
+        return node;
+    }
+
+    public void setPosition(int position) {
+        this.position = position;
+    }
+
+    public int getPosition() {
+        return position;
     }
 
     public long getPointer() {

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/ReferenceList.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/gc/ReferenceList.java
@@ -1,0 +1,81 @@
+package com.badlogic.gdx.jnigen.runtime.gc;
+
+
+public final class ReferenceList {
+
+    private ReferenceListNode head;
+    private ReferenceListNode poolCache;
+    private long size;
+
+    public ReferenceList() {
+        this.head = new ReferenceListNode();
+    }
+
+    public synchronized void insertReference(PointingPhantomReference reference) {
+        if (head.size >= ReferenceListNode.NODE_SIZE) {
+            if (poolCache != null) {
+                poolCache.next = head;
+                head = poolCache;
+                poolCache = null;
+            } else {
+                ReferenceListNode newHead = new ReferenceListNode();
+                newHead.next = head;
+                head = newHead;
+            }
+        }
+
+        head.addNode(reference);
+        size++;
+    }
+
+    public synchronized void removeReference(PointingPhantomReference reference) {
+        PointingPhantomReference headLastNode = head.getLastNode();
+        if (headLastNode != reference) {
+            reference.getNode().setNode(headLastNode, reference.getPosition());
+        }
+
+        head.removeLastNode();
+
+        if (head.size == 0 && head.next != null) {
+            if (poolCache == null) {
+                poolCache = head;
+            }
+            head = head.next;
+        }
+        size--;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public final static class ReferenceListNode {
+        private static final int NODE_SIZE = 4096;
+
+        private final PointingPhantomReference[] elements = new PointingPhantomReference[NODE_SIZE];
+        private int size = 0;
+        private ReferenceListNode next = null;
+
+        public void addNode(PointingPhantomReference reference) {
+            reference.setNode(this);
+            reference.setPosition(size);
+            elements[size] = reference;
+            size++;
+        }
+
+        public void setNode(PointingPhantomReference reference, int position) {
+            reference.setPosition(position);
+            reference.setNode(this);
+            elements[position] = reference;
+        }
+
+        public PointingPhantomReference getLastNode() {
+            return elements[size - 1];
+        }
+
+        public void removeLastNode() {
+            elements[size - 1] = null;
+            size--;
+        }
+    }
+}

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/CSizedIntPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/CSizedIntPointer.java
@@ -167,8 +167,9 @@ public final class CSizedIntPointer extends Pointing {
     }
 
     public CSizedIntPointer recast(String newCType) {
-        CSizedIntPointer tmp = new CSizedIntPointer(getPointer(), getsGCFreed(), newCType);
+        CSizedIntPointer tmp = new CSizedIntPointer(getPointer(), false, newCType);
         tmp.guardBytes(getSizeGuard());
+        tmp.setParent(this);
         return tmp;
     }
 

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/CSizedIntPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/CSizedIntPointer.java
@@ -1,7 +1,7 @@
 package com.badlogic.gdx.jnigen.runtime.pointer;
 
 import com.badlogic.gdx.jnigen.runtime.CHandler;
-import com.badlogic.gdx.jnigen.runtime.c.CTypeInfo;;
+import com.badlogic.gdx.jnigen.runtime.c.CTypeInfo;
 
 public final class CSizedIntPointer extends Pointing {
 

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/PointerDereferenceSupplier.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/PointerDereferenceSupplier.java
@@ -1,6 +1,5 @@
 package com.badlogic.gdx.jnigen.runtime.pointer;
 
-@FunctionalInterface
 public interface PointerDereferenceSupplier<S extends Pointing> {
 
     S create(long pointer, boolean freeOnGC);

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
@@ -19,7 +19,7 @@ public class Pointing {
         this.pointer = pointer;
         this.freeOnGC = freeOnGC;
         if (freeOnGC)
-            GCHandler.enqueuePointer(this, pointer);
+            GCHandler.enqueuePointer(this);
     }
 
     public Pointing(int size, boolean freeOnGC, boolean guard) {

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
@@ -2,7 +2,6 @@ package com.badlogic.gdx.jnigen.runtime.pointer;
 
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.gc.GCHandler;
-import com.badlogic.gdx.jnigen.runtime.gc.PointingPhantomReference;
 
 public class Pointing {
     private final long pointer;

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Pointing.java
@@ -2,11 +2,13 @@ package com.badlogic.gdx.jnigen.runtime.pointer;
 
 import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.gc.GCHandler;
+import com.badlogic.gdx.jnigen.runtime.gc.PointingPhantomReference;
 
 public class Pointing {
     private final long pointer;
     protected boolean freed;
     private final boolean freeOnGC;
+    private Pointing parent;
 
     /**
      * This is just a hint to an implementor of Pointing to respect a bound, but it doesn't have too
@@ -48,12 +50,14 @@ public class Pointing {
     public void free() {
         if (freed)
             throw new IllegalStateException("Double free on " + pointer);
-        if (freeOnGC)
+        if (getsGCFreed())
             throw new IllegalStateException("Can't free a object, that gets freed by GC.");
-        if (GCHandler.isEnqueued(pointer))
-            throw new IllegalStateException("Can't free object, when another object with the same pointer will be freed by GC.");
         CHandler.free(pointer);
         freed = true;
+    }
+
+    public void setParent(Pointing parent) {
+        this.parent = parent;
     }
 
     public boolean isFreed() {
@@ -61,6 +65,8 @@ public class Pointing {
     }
 
     public boolean getsGCFreed() {
+        if (parent != null)
+            return parent.getsGCFreed();
         return freeOnGC;
     }
 

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/StackElementPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/StackElementPointer.java
@@ -41,8 +41,7 @@ public abstract class StackElementPointer<T extends StackElement> extends Pointi
         int offset = getSize() * index;
         assertBounds(offset);
         T stackElement = createStackElement(getPointer() + offset, false);
-        if (getsGCFreed())
-            GCHandler.enqueuePointer(stackElement, getPointer());
+        stackElement.setParent(this);
         return stackElement;
     }
 

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/StackElementPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/StackElementPointer.java
@@ -1,7 +1,6 @@
 package com.badlogic.gdx.jnigen.runtime.pointer;
 
 import com.badlogic.gdx.jnigen.runtime.CHandler;
-import com.badlogic.gdx.jnigen.runtime.gc.GCHandler;
 
 public abstract class StackElementPointer<T extends StackElement> extends Pointing {
 

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Struct.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Struct.java
@@ -1,7 +1,5 @@
 package com.badlogic.gdx.jnigen.runtime.pointer;
 
-import com.badlogic.gdx.jnigen.runtime.CHandler;
-
 public abstract class Struct extends StackElement {
 
     protected Struct(long pointer, boolean freeOnGC) {

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Union.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/Union.java
@@ -1,7 +1,5 @@
 package com.badlogic.gdx.jnigen.runtime.pointer;
 
-import com.badlogic.gdx.jnigen.runtime.CHandler;
-
 public abstract class Union extends StackElement {
 
     protected Union(long pointer, boolean freeOnGC) {

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/VoidPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/VoidPointer.java
@@ -22,20 +22,23 @@ public final class VoidPointer extends Pointing {
     }
 
     public CSizedIntPointer recastToInt(String cType) {
-        CSizedIntPointer tmp = new CSizedIntPointer(getPointer(), getsGCFreed(), cType);
+        CSizedIntPointer tmp = new CSizedIntPointer(getPointer(), false, cType);
         tmp.guardBytes(getSizeGuard());
+        tmp.setParent(this);
         return tmp;
     }
 
     public FloatPointer recastToFloat() {
-        FloatPointer tmp = new FloatPointer(getPointer(), getsGCFreed());
+        FloatPointer tmp = new FloatPointer(getPointer(), false);
         tmp.guardBytes(getSizeGuard());
+        tmp.setParent(this);
         return tmp;
     }
 
     public DoublePointer recastToDouble() {
-        DoublePointer tmp = new DoublePointer(getPointer(), getsGCFreed());
+        DoublePointer tmp = new DoublePointer(getPointer(), false);
         tmp.guardBytes(getSizeGuard());
+        tmp.setParent(this);
         return tmp;
     }
 }

--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/util/DowncallClosureSupplier.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/util/DowncallClosureSupplier.java
@@ -2,7 +2,6 @@ package com.badlogic.gdx.jnigen.runtime.util;
 
 import com.badlogic.gdx.jnigen.runtime.closure.Closure;
 
-@FunctionalInterface
 public interface DowncallClosureSupplier<T extends Closure> {
 
     T get(long fnPtr);


### PR DESCRIPTION
This PR does two things:
1. It removes the ARC when recasting objects. It adds nice safety, but it's just too expensive. This drastically improves performance for pointer queuing/dequeing
2. It optimizes the GCHandler phantom reference storage. Instead of having one big HashSet, it holds references in a linked list, that contains phantom reference arrays. This drastically improves performance for pointer queuing/dequeing

Overall, the changes improve performance a lot, when many native objects are involved.

Fixes https://github.com/libgdx/gdx-jnigen/issues/97