### PR TITLE
jnigen generator maintenance

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -191,10 +191,10 @@ jobs:
 
       - name: Download NDK
         run: |
-          wget https://dl.google.com/android/repository/android-ndk-r25c-linux.zip -O android-ndk.zip
+          wget https://dl.google.com/android/repository/android-ndk-r27d-linux.zip -O android-ndk.zip
           echo "769ee342ea75f80619d985c2da990c48b3d8eaf45f48783a2d48870d04b46108  android-ndk.zip" | sha256sum --check
           unzip android-ndk.zip
-          echo "NDK_HOME=$(pwd)/android-ndk-r25c" >> $GITHUB_ENV
+          echo "NDK_HOME=$(pwd)/android-ndk-r27d" >> $GITHUB_ENV
 
       - name: Build Android natives
         run: |

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/StackElementType.java
@@ -248,6 +248,22 @@ public class StackElementType implements MappedType, WritableClass {
 
             setBody.addStatement(fieldType.getDefinition().getMappedType().writeToBufferPtr(new MethodCallExpr("getBufPtr"), getFieldOffsetAsExpression(i), fieldType.getDefinition().getMappedType().toC(new NameExpr(fieldType.getName()))));
             setMethod.setBody(setBody);
+
+            if (fieldType.getDefinition().getTypeKind() == TypeKind.POINTER) {
+                MethodDeclaration getAllocFreeMethod = toWriteToPublic.addMethod(JavaUtils.getGetter(fieldType.getName()), Keyword.PUBLIC)
+                        .addParameter(fieldType.getDefinition().getMappedType().abstractType(), "toSetPtr");
+                if (field.getComment() != null)
+                    getAllocFreeMethod.setJavadocComment(field.getComment());
+                BlockStmt getAllocFreeBody = new BlockStmt();
+
+                Expression fromBufferPointer = fieldType.getDefinition().getMappedType().readFromBufferPtr(new MethodCallExpr("getBufPtr"), getFieldOffsetAsExpression(i));
+                MethodCallExpr setPtr = new MethodCallExpr("setPointer")
+                        .setScope(new NameExpr("toSetPtr"))
+                        .addArgument(fromBufferPointer);
+
+                getAllocFreeBody.addStatement(setPtr);
+                getAllocFreeMethod.setBody(getAllocFreeBody);
+            }
         }
 
         // Pointer

--- a/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/structs/GlobalArg.java
+++ b/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/structs/GlobalArg.java
@@ -126,12 +126,20 @@ public final class GlobalArg extends Union {
         getBufPtr().setNativePointer(0, intPtr.getPointer());
     }
 
+    public void getIntPtr(SIntPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
+    }
+
     public PointerPointer<SIntPointer> intPtrPtr() {
         return new PointerPointer<>(getBufPtr().getNativePointer(0), false, SIntPointer::new);
     }
 
     public void intPtrPtr(PointerPointer<SIntPointer> intPtrPtr) {
         getBufPtr().setNativePointer(0, intPtrPtr.getPointer());
+    }
+
+    public void getIntPtrPtr(PointerPointer<SIntPointer> toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
     }
 
     public TestStruct structVal() {
@@ -162,6 +170,10 @@ public final class GlobalArg extends Union {
         getBufPtr().setNativePointer(0, structPtr.getPointer());
     }
 
+    public void getStructPtr(TestStruct.TestStructPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
+    }
+
     public TestEnum enumVal() {
         return TestEnum.getByIndex((int) getBufPtr().getUInt(0));
     }
@@ -178,12 +190,20 @@ public final class GlobalArg extends Union {
         getBufPtr().setNativePointer(0, enumPtr.getPointer());
     }
 
+    public void getEnumPtr(TestEnum.TestEnumPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
+    }
+
     public TestUnion.TestUnionPointer unionPtr() {
         return new TestUnion.TestUnionPointer(getBufPtr().getNativePointer(0), false);
     }
 
     public void unionPtr(TestUnion.TestUnionPointer unionPtr) {
         getBufPtr().setNativePointer(0, unionPtr.getPointer());
+    }
+
+    public void getUnionPtr(TestUnion.TestUnionPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
     }
 
     public allArgs allArgs() {

--- a/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/structs/SpecialStruct.java
+++ b/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/structs/SpecialStruct.java
@@ -60,6 +60,10 @@ public final class SpecialStruct extends Struct {
         getBufPtr().setNativePointer(0, floatPtrField.getPointer());
     }
 
+    public void getFloatPtrField(FloatPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(0));
+    }
+
     public SIntPointer arrayField() {
         return new SIntPointer(getPointer() + (CHandler.IS_64_BIT ? 8 : 4), false, 5);
     }
@@ -86,6 +90,10 @@ public final class SpecialStruct extends Struct {
 
     public void intPtrField(SIntPointer intPtrField) {
         getBufPtr().setNativePointer(CHandler.IS_64_BIT ? 32 : 24, intPtrField.getPointer());
+    }
+
+    public void getIntPtrField(SIntPointer toSetPtr) {
+        toSetPtr.setPointer(getBufPtr().getNativePointer(CHandler.IS_64_BIT ? 32 : 24));
     }
 
     public static final class SpecialStructPointer extends StackElementPointer<SpecialStruct> {

--- a/gdx-jnigen-runtime/build.gradle
+++ b/gdx-jnigen-runtime/build.gradle
@@ -152,28 +152,6 @@ task build_ios {
     dependsOn createBuildTask("iphonesimulator", "x86_64", "-arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk", ["--host=x86_64-apple-ios-simulator"])
 }
 
-
-task extractAndroidCXXLibs() {
-    doLast {
-        if (!new File(System.getenv("NDK_HOME") + "/toolchains/llvm/prebuilt/").exists())
-            throw new IllegalArgumentException("NDK_HOME ${System.getenv("NDK_HOME")} does not point to a valid NDK")
-        def osPath = new File(System.getenv("NDK_HOME") + "/toolchains/llvm/prebuilt/").listFiles()[0].getName()
-        def basePath = System.getenv("NDK_HOME") + "/toolchains/llvm/prebuilt/${osPath}/sysroot/usr/lib/"
-
-        ["x86": "i686-linux-android", "x86_64": "x86_64-linux-android", "armeabi-v7a": "arm-linux-androideabi",
-         "arm64-v8a": "aarch64-linux-android"]
-        .forEach { arch, path ->
-            def sourcePath = "$basePath/$path/libc++_shared.so"
-            if (!new File(sourcePath).exists())
-                throw new IllegalArgumentException("Path ${sourcePath} does not exist")
-            copy {
-                from sourcePath
-                into file("libs/$arch/")
-            }
-        }
-    }
-}
-
 jnigen {
     sharedLibName = "jnigen-runtime"
 
@@ -216,13 +194,6 @@ jnigen {
         ]
     }
     addIOS()
-}
-
-jnigenBuildAllAndroid.dependsOn(extractAndroidCXXLibs)
-tasks.forEach {
-    if (it.name.startsWith("jnigenBuildAndroid")) {
-        it.dependsOn(extractAndroidCXXLibs)
-    }
 }
 
 


### PR DESCRIPTION
Small changeset:
- Bump build NDK to 27d, so that the libc++ is compatible with 16kb page sizes. NDK supports android 21+, which is fine for us.
- Remove some legacy code
- Add overloads to save an allocation when working with pointer in structs