### PR TITLE
Don't strip android libs

### DIFF
--- a/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template
+++ b/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/scripts/Application.mk.template
@@ -1,2 +1,3 @@
 APP_ABI := %androidABIs%
 APP_PLATFORM := android-9
+APP_STRIP_MODE := none


### PR DESCRIPTION
This is part of https://github.com/libgdx/gdx-jnigen/issues/74.
AGP/playstore should strip the symbols on release anyway.
If a specific user doesn't want this behaviour, they can manually opt out with `androidApplicationMk = ["APP_STRIP_MODE = --strip-unneded"]`. I didn't saw a need for a new special flag/field.