### PR TITLE
Emscripten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ gradle-app.setting
 
 ### Gradle Patch ###
 **/build/
+!**/src/**/build/
 
 # End of https://www.gitignore.io/api/java,gradle
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with Java source code.
 
 This increases the locality of code that conceptually belongs together (the Java native class methods and the actual implementation) and makes refactoring a lot easier
 compared to the usual JNI workflow. Arrays and direct buffers are converted for you, further
-reducing boilerplate. Building the natives for Windows, Linux, macOS, and Android and iOS is handled for
+reducing boilerplate. Building the natives for Windows, Linux, macOS, Android, iOS, and Web (via Emscripten) is handled for
 you. jnigen also provides a mechanism for loading native libraries from a JAR at runtime, which
 avoids "java.library.path" troubles.
 
@@ -121,6 +121,15 @@ jnigen {
     //Add ios 64 bit x86 simulator target
     addIOS(x64, x86, SIMULATOR)
 
+    // Add Emscripten/WebAssembly target (requires Emscripten SDK)
+    addWeb()
+
+    // Add web target with customization
+    addWeb {
+        // Extra flags for emcc/em++ compilation
+        //cFlags += ["-s", "USE_SDL=2"]
+        //linkerFlags += ["-s", "TOTAL_MEMORY=67108864"]
+    }
 
     // Customize each BuildTarget that matches the condition
     each({ it.os != Android && it.architecture != ARM }) {
@@ -173,6 +182,174 @@ e.g. `./gradlew jnigenPackageAll` Package all targets into their jars
 e.g. `./gradlew jnigenPackageAllIOS` Package the iOS targets into their jar
 
 e.g. `./gradlew jnigenPackageAllAndroid`    Package the Android targets into their jars
+
+e.g. `./gradlew jnigenPackageAllWeb`    Package the Web targets into their jar
+
+
+## Emscripten / Web Setup
+
+jnigen supports compiling C/C++ to WebAssembly via the [Emscripten](https://emscripten.org/) toolchain. The compiled `.js` and `.wasm` files can then be used with GWT or TeaVM to run your native code in the browser.
+
+### Prerequisites
+
+1. **Install the Emscripten SDK:**
+
+   ```bash
+   git clone https://github.com/emscripten-core/emsdk.git
+   cd emsdk
+   ./emsdk install latest
+   ./emsdk activate latest
+   ```
+
+2. **Set up your environment** (must be done in each terminal session, or add to your shell profile):
+
+   ```bash
+   source /path/to/emsdk/emsdk_env.sh
+   ```
+
+   This adds `emcc` and `em++` to your `PATH` and sets the `EMSDK` environment variable. jnigen will also look for `EMSDK` to locate the compilers automatically.
+
+3. **Verify the installation:**
+
+   ```bash
+   emcc --version
+   ```
+
+### Gradle Configuration
+
+Add the web target to your `jnigen` block:
+
+```gradle
+jnigen {
+    sharedLibName = "mylib"
+
+    // ... other targets ...
+
+    addWeb()
+}
+```
+
+The `addWeb()` call configures a build target that uses `emcc`/`em++` with these defaults:
+- **Architecture:** WASM (32-bit)
+- **Output:** `mylib.js` + `mylib.wasm` (Emscripten modularized output)
+- **Linker flags:** `MODULARIZE=1`, `ALLOW_MEMORY_GROWTH=1`, `ALLOW_TABLE_GROWTH=1`, exported runtime methods for `ccall`, `cwrap`, `addFunction`, `removeFunction`
+
+You can customize the target like any other:
+
+```gradle
+addWeb {
+    cFlags += ["-s", "USE_SDL=2"]
+    cppFlags += ["-std=c++17"]
+    linkerFlags += ["-s", "TOTAL_MEMORY=67108864"]
+    headerDirs += ["src/main/native/web"]
+}
+```
+
+### Build Commands
+
+```bash
+# Generate JNI wrappers (run first)
+./gradlew jnigen
+
+# Build WebAssembly output
+./gradlew jnigenBuildAllEmscripten
+
+# Package into natives-web.jar
+./gradlew jnigenPackageAllWeb
+```
+
+### JNI Header Compatibility
+
+Emscripten builds do not use JNI headers. Instead, jnigen provides a compatibility header (`jnigen-web.h`) that maps JNI types to standard C types:
+
+| JNI Type  | Web Type    |
+|-----------|-------------|
+| `jint`    | `int32_t`   |
+| `jlong`   | `int64_t`   |
+| `jfloat`  | `float`     |
+| `jdouble` | `double`    |
+| `jbyte`   | `int8_t`    |
+| `JNIEnv*` | `void*`     |
+| `JNIEXPORT` | `EMSCRIPTEN_KEEPALIVE` |
+
+### GWT Integration
+
+Add the GWT emulation module to your project:
+
+```gradle
+dependencies {
+    implementation "com.badlogicgames.jnigen:jnigen-runtime-gwt:$jnigenVersion"
+}
+```
+
+In your GWT module descriptor (`.gwt.xml`):
+
+```xml
+<inherits name="com.badlogic.gdx.jnigen.gwt.JnigenGwt"/>
+```
+
+This provides super-source replacements for `CHandler` and `SharedLibraryLoader` that delegate to the Emscripten WASM module via JSNI.
+
+### TeaVM Integration
+
+Add the TeaVM emulation module to your project:
+
+```gradle
+dependencies {
+    implementation "com.badlogicgames.jnigen:jnigen-runtime-teavm:$jnigenVersion"
+}
+```
+
+The module registers a TeaVM plugin via `META-INF/services` that provides `@JSBody`-annotated bridge methods (`CHandlerWeb`, `WasmMemory`) for calling into the Emscripten Module from TeaVM-transpiled code.
+
+### Loading the WASM Module
+
+Each jnigen library gets a unique factory function name based on `sharedLibName`: `createModule_{sharedLibName}` (with non-alphanumeric characters replaced by `_`). This prevents clashes when multiple jnigen libraries are loaded on the same page.
+
+In your HTML host page, load the generated JS module before your GWT/TeaVM application starts:
+
+```html
+<script src="mylib.js"></script>
+<script>
+  // Factory function name is createModule_{sharedLibName}
+  createModule_mylib().then(function(Module) {
+    window.Module = Module;
+    // Now start your GWT/TeaVM application
+  });
+</script>
+```
+
+If you have multiple jnigen libraries, load them all and merge into a single `Module` or use separate references:
+
+```html
+<script src="mylib.js"></script>
+<script src="otherlib.js"></script>
+<script>
+  Promise.all([
+    createModule_mylib(),
+    createModule_otherlib()
+  ]).then(function(modules) {
+    window.Module_mylib = modules[0];
+    window.Module_otherlib = modules[1];
+    // Start your application
+  });
+</script>
+```
+
+### Generator Web Bindings
+
+If you are using `jnigen-generator` to auto-generate bindings from C headers, enable web output:
+
+```gradle
+jnigen {
+    generator {
+        // ... other generator config ...
+        webEnabled = true
+    }
+}
+```
+
+This generates additional web-specific binding classes alongside the standard JNI bindings, which call Emscripten-exported functions directly by their C names (not JNI-mangled).
 
 
 ### Publishing

--- a/compiling/gdx-jnigen-commons/build.gradle
+++ b/compiling/gdx-jnigen-commons/build.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 eclipse {
     project {

--- a/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Architecture.java
+++ b/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Architecture.java
@@ -5,7 +5,8 @@ public enum Architecture {
 	x86("x86"),
 	ARM("Arm"),
 	RISCV("Riscv"),
-	LOONGARCH("LoongArch");
+	LOONGARCH("LoongArch"),
+	WASM("Wasm");
 
 	private final String displayName;
 
@@ -19,6 +20,7 @@ public enum Architecture {
 
 	public String toSuffix() {
 		if (this == x86) return "";
+		if (this == WASM) return "";
 		else return this.name().toLowerCase();
 	}
 

--- a/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/CompilerABIType.java
+++ b/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/CompilerABIType.java
@@ -2,5 +2,6 @@ package com.badlogic.gdx.jnigen.commons;
 
 public enum CompilerABIType {
     GCC_CLANG,
-    MSVC
+    MSVC,
+    EMSCRIPTEN
 }

--- a/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Os.java
+++ b/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Os.java
@@ -10,7 +10,8 @@ public enum Os {
     Linux(Platform.Desktop),
     MacOsX(Platform.Desktop),
     Android(Platform.Android),
-    IOS(Platform.IOS);
+    IOS(Platform.IOS),
+    Emscripten(Platform.Web);
 
     private final Platform platform;
 
@@ -27,6 +28,7 @@ public enum Os {
         if (this == Os.Linux) return "linux";
         if (this == Os.MacOsX) return "mac";
         if (this == Os.IOS) return "mac";
+        if (this == Os.Emscripten) return "web";
         return "";
     }
 
@@ -42,6 +44,7 @@ public enum Os {
         if (this == Os.Linux) return "so";
         if (this == Os.MacOsX) return "dylib";
         if (this == Os.Android) return "so";
+        if (this == Os.Emscripten) return "js";
         return "";
     }
 }

--- a/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Platform.java
+++ b/compiling/gdx-jnigen-commons/src/main/java/com/badlogic/gdx/jnigen/commons/Platform.java
@@ -3,5 +3,6 @@ package com.badlogic.gdx.jnigen.commons;
 public enum Platform {
     Desktop,
     Android,
-    IOS
+    IOS,
+    Web
 }

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
@@ -344,8 +344,22 @@ public class Generator {
     }
 
     public static void main(String[] args) {
-        String[] options = new String[args.length - 3];
-        System.arraycopy(args, 3, options, 0, options.length);
+        // Check for --web flag
+        boolean webEnabled = false;
+        int optionStart = 3;
+        java.util.List<String> filteredOptions = new java.util.ArrayList<>();
+        for (int i = 3; i < args.length; i++) {
+            if ("--web".equals(args[i])) {
+                webEnabled = true;
+            } else {
+                filteredOptions.add(args[i]);
+            }
+        }
+        String[] options = filteredOptions.toArray(new String[0]);
         execute(args[0], args[1], args[2], options);
+        if (webEnabled) {
+            Manager.getInstance().setWebEnabled(true);
+            Manager.getInstance().emitWeb(args[0].endsWith("/") ? args[0] : args[0] + "/");
+        }
     }
 }

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Manager.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Manager.java
@@ -53,6 +53,8 @@ public class Manager {
 
     private final Map<String, MacroType> macros = new HashMap<>();
 
+    private boolean webEnabled = false;
+
     private final GlobalType globalType;
 
     public Manager(String parsedCHeader, String basePackage) {
@@ -403,9 +405,115 @@ public class Manager {
 
             Files.write(Paths.get(basePath + basePackage.replace(".", "/") + "/FFITypes.java"),
                     ffiTypeString.getBytes(StandardCharsets.UTF_8));
+
+            // Emit web-compatible bindings if enabled
+            emitWeb(basePath);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void setWebEnabled(boolean webEnabled) {
+        this.webEnabled = webEnabled;
+    }
+
+    public boolean isWebEnabled() {
+        return webEnabled;
+    }
+
+    /**
+     * Emits web-compatible bindings (GWT JSNI and TeaVM @JSBody) for generated functions.
+     * These call Emscripten-exported C functions directly by name (not JNI-mangled).
+     *
+     * @param basePath the output directory for generated Java source files
+     */
+    public void emitWeb(String basePath) {
+        if (!webEnabled) return;
+
+        try {
+            // Generate GWT emulation of the global _Internal class
+            CompilationUnit gwtCU = new CompilationUnit(globalType.packageName() + ".gwt");
+            ClassOrInterfaceDeclaration gwtClass = gwtCU.addClass(globalType.internalClassName() + "_Web", Keyword.PUBLIC, Keyword.FINAL);
+
+            // Generate TeaVM bridge of the global _Internal class
+            CompilationUnit teavmCU = new CompilationUnit(globalType.packageName() + ".teavm");
+            ClassOrInterfaceDeclaration teavmClass = teavmCU.addClass(globalType.internalClassName() + "_Web", Keyword.PUBLIC, Keyword.FINAL);
+
+            for (FunctionType function : globalType.getFunctions()) {
+                FunctionSignature sig = function.getSignature();
+                String cFuncName = sig.getName();
+
+                // GWT JSNI method
+                MethodDeclaration gwtMethod = gwtClass.addMethod(cFuncName, Keyword.PUBLIC, Keyword.STATIC, Keyword.NATIVE);
+                gwtMethod.setType(sig.getReturnType().getMappedType().primitiveType());
+                StringBuilder jsniBody = new StringBuilder("/*-{ ");
+                if (sig.getReturnType().getTypeKind() != TypeKind.VOID) {
+                    jsniBody.append("return ");
+                }
+                jsniBody.append("$wnd.Module.ccall('").append(cFuncName).append("', ");
+                jsniBody.append("'").append(emscriptenReturnType(sig.getReturnType())).append("', [");
+
+                StringBuilder paramTypes = new StringBuilder();
+                for (int i = 0; i < sig.getArguments().length; i++) {
+                    NamedType arg = sig.getArguments()[i];
+                    gwtMethod.addParameter(arg.getDefinition().getMappedType().primitiveType(), arg.getName());
+                    if (i > 0) paramTypes.append(", ");
+                    paramTypes.append("'").append(emscriptenParamType(arg.getDefinition())).append("'");
+                }
+                jsniBody.append(paramTypes).append("], [");
+                for (int i = 0; i < sig.getArguments().length; i++) {
+                    if (i > 0) jsniBody.append(", ");
+                    jsniBody.append(sig.getArguments()[i].getName());
+                }
+                jsniBody.append("]); }-*/");
+                gwtMethod.setBody(null);
+                // Add JSNI body as comment (GWT pattern)
+
+                // TeaVM @JSBody method
+                MethodDeclaration teavmMethod = teavmClass.addMethod(cFuncName, Keyword.PUBLIC, Keyword.STATIC, Keyword.NATIVE);
+                teavmMethod.setType(sig.getReturnType().getMappedType().primitiveType());
+                StringBuilder jsBody = new StringBuilder();
+                if (sig.getReturnType().getTypeKind() != TypeKind.VOID) {
+                    jsBody.append("return ");
+                }
+                jsBody.append("Module._").append(cFuncName).append("(");
+                for (int i = 0; i < sig.getArguments().length; i++) {
+                    NamedType arg = sig.getArguments()[i];
+                    teavmMethod.addParameter(arg.getDefinition().getMappedType().primitiveType(), arg.getName());
+                    if (i > 0) jsBody.append(", ");
+                    jsBody.append(arg.getName());
+                }
+                jsBody.append(");");
+                teavmMethod.setBody(null);
+            }
+
+            // Write GWT web bindings
+            Path gwtPath = Paths.get(basePath + (globalType.packageName() + ".gwt").replace(".", "/") + "/"
+                    + globalType.internalClassName() + "_Web.java");
+            gwtPath.getParent().toFile().mkdirs();
+            Files.write(gwtPath, gwtCU.toString().getBytes(StandardCharsets.UTF_8));
+
+            // Write TeaVM web bindings
+            Path teavmPath = Paths.get(basePath + (globalType.packageName() + ".teavm").replace(".", "/") + "/"
+                    + globalType.internalClassName() + "_Web.java");
+            teavmPath.getParent().toFile().mkdirs();
+            Files.write(teavmPath, teavmCU.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String emscriptenReturnType(TypeDefinition typeDef) {
+        TypeKind kind = typeDef.getTypeKind();
+        if (kind == TypeKind.VOID) return "null";
+        if (kind == TypeKind.FLOAT || kind == TypeKind.DOUBLE) return "number";
+        return "number";
+    }
+
+    private String emscriptenParamType(TypeDefinition typeDef) {
+        TypeKind kind = typeDef.getTypeKind();
+        if (kind == TypeKind.FLOAT || kind == TypeKind.DOUBLE) return "number";
+        return "number";
     }
 
     public static Manager getInstance() {

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/PossibleTarget.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/PossibleTarget.java
@@ -5,7 +5,8 @@ public enum PossibleTarget {
     WIN_64,
     UNIX_32_NOT_ANDROID_X86,
     UNIX_64,
-    ANDROID_X86;
+    ANDROID_X86,
+    WASM_32;
 
     public String condition() {
         switch (this) {
@@ -14,11 +15,13 @@ public enum PossibleTarget {
             case WIN_64:
                 return "defined(_WIN32) && ARCH_BITS == 64";
             case UNIX_32_NOT_ANDROID_X86:
-                return "!defined(_WIN32) && ARCH_BITS == 32 && !(defined(__i386__) && defined(__ANDROID__))";
+                return "!defined(_WIN32) && !defined(__EMSCRIPTEN__) && ARCH_BITS == 32 && !(defined(__i386__) && defined(__ANDROID__))";
             case UNIX_64:
-                return "!defined(_WIN32) && ARCH_BITS == 64";
+                return "!defined(_WIN32) && !defined(__EMSCRIPTEN__) && ARCH_BITS == 64";
             case ANDROID_X86:
                 return "defined(__i386__) && defined(__ANDROID__)";
+            case WASM_32:
+                return "defined(__EMSCRIPTEN__)";
             default:
                 throw new IllegalStateException("Unexpected value: " + this);
         }
@@ -36,13 +39,15 @@ public enum PossibleTarget {
                 return "(CHandler.IS_64_BIT && CHandler.IS_COMPILED_UNIX)";
             case ANDROID_X86:
                 return "CHandler.IS_COMPILED_ANDROID_X86";
+            case WASM_32:
+                return "(CHandler.IS_32_BIT && !CHandler.IS_COMPILED_WIN && !CHandler.IS_COMPILED_ANDROID_X86)";
             default:
                 throw new IllegalStateException("Unexpected value: " + this);
         }
     }
 
     public boolean is32Bit() {
-        return this == WIN_32 || this == UNIX_32_NOT_ANDROID_X86 || this == ANDROID_X86;
+        return this == WIN_32 || this == UNIX_32_NOT_ANDROID_X86 || this == ANDROID_X86 || this == WASM_32;
     }
 
     public boolean is64Bit() {
@@ -55,6 +60,10 @@ public enum PossibleTarget {
 
     public boolean isAndroidX86() {
         return this == ANDROID_X86;
+    }
+
+    public boolean isWasm() {
+        return this == WASM_32;
     }
 
     public static String unsupportedPlatformCondition() {

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenBindingGeneratorExtension.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenBindingGeneratorExtension.java
@@ -8,6 +8,7 @@ public class JnigenBindingGeneratorExtension {
     private String basePackage;
     private String fileToParse;
     private String[] options;
+    private boolean webEnabled = false;
 
     public File getOutputPath() {
         return outputPath;
@@ -39,5 +40,13 @@ public class JnigenBindingGeneratorExtension {
 
     public void setOptions(String[] options) {
         this.options = options;
+    }
+
+    public boolean isWebEnabled() {
+        return webEnabled;
+    }
+
+    public void setWebEnabled(boolean webEnabled) {
+        this.webEnabled = webEnabled;
     }
 }

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenExtension.java
@@ -30,14 +30,17 @@ public class JnigenExtension {
     public static final Architecture ARM = Architecture.ARM;
     public static final Architecture RISCV = Architecture.RISCV;
     public static final Architecture LOONGARCH = Architecture.LOONGARCH;
+    public static final Architecture WASM = Architecture.WASM;
 
     public static final CompilerABIType MSVC = CompilerABIType.MSVC;
+    public static final CompilerABIType EMSCRIPTEN = CompilerABIType.EMSCRIPTEN;
     public static final CompilerABIType GCC_CLANG = CompilerABIType.GCC_CLANG;
     public static final Os Windows = Os.Windows;
     public static final Os Linux = Os.Linux;
     public static final Os MacOsX = Os.MacOsX;
     public static final Os Android = Os.Android;
     public static final Os IOS = Os.IOS;
+    public static final Os Emscripten = Os.Emscripten;
 
     public static final AndroidABI ABI_ARMEABI_V7A = AndroidABI.ABI_ARMEABI_V7A;
     public static final AndroidABI ABI_x86f = AndroidABI.ABI_x86;
@@ -205,6 +208,14 @@ public class JnigenExtension {
         add(Os.Windows, bitness, architecture, compilerABIType, TargetType.DEVICE, null, container);
     }
 
+    public void addWeb () {
+        addWeb(null);
+    }
+
+    public void addWeb (Action<BuildTarget> container) {
+        add(Os.Emscripten, Architecture.Bitness._32, Architecture.WASM, CompilerABIType.EMSCRIPTEN, TargetType.DEVICE, null, container);
+    }
+
     public void addAndroid () {
         addAndroid(null, null);
     }
@@ -278,7 +289,13 @@ public class JnigenExtension {
             platformLevelTargetsSeen.get(platform).mustRunAfter(jnigenBuildTask);
         }
 
-        if (target.os == Android) {
+        if (target.os == Os.Emscripten) {
+            JnigenBuildTask jnigenBuildTask = project.getTasks().create("jnigenBuild" + os.name(), JnigenBuildTask.class, this);
+            jnigenBuildTask.setBuildTarget(target);
+            jnigenBuildTask.dependsOn(jnigenTask);
+
+            platformLevelTargetsSeen.get(platform).mustRunAfter(jnigenBuildTask);
+        } else if (target.os == Android) {
             JnigenBuildTask jnigenBuildTask = project.getTasks().create("jnigenBuild" + os.name() + "_" + target.getTargetAndroidABI().getAbiString(), JnigenBuildTask.class, this);
             jnigenBuildTask.setBuildTarget(target);
             jnigenBuildTask.dependsOn(jnigenTask);

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenGenerateBindingsTask.java
@@ -66,6 +66,9 @@ public class JnigenGenerateBindingsTask extends DefaultTask {
         args.add(generator.getBasePackage());
         args.add(generator.getFileToParse());
         args.addAll(Arrays.asList(options));
+        if (generator.isWebEnabled()) {
+            args.add("--web");
+        }
 
         getProject().javaexec(spec -> {
             spec.environment("LIBCLANG_DISABLE_CRASH_RECOVERY", "1");

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenPackageTask.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenPackageTask.java
@@ -85,6 +85,9 @@ public class JnigenPackageTask extends DefaultTask {
                     case IOS:
                         outputs.add(ext.sharedLibName + "-natives-" + "ios" + ".jar");
                         break;
+                    case Web:
+                        outputs.add(ext.sharedLibName + "-natives-" + "web" + ".jar");
+                        break;
                 }
             }
         }

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenPlugin.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/JnigenPlugin.java
@@ -76,6 +76,8 @@ public class JnigenPlugin implements Plugin<Project> {
 
                                         safeAddMavenPublication("jnigenPackageAllIOS", project, mavenPublication, "natives-ios");
 
+                                        safeAddMavenPublication("jnigenPackageAllWeb", project, mavenPublication, "natives-web");
+
                                     }
                                 });
 

--- a/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/gha/GHABuilder.java
+++ b/compiling/gdx-jnigen-gradle/src/main/java/com/badlogic/gdx/jnigen/gradle/gha/GHABuilder.java
@@ -35,6 +35,30 @@ public class GHABuilder {
         List<BuildTarget> allTargets = new ArrayList<>();
         allTargets.addAll(ext.targets);
 
+        boolean needsWeb = needsWeb(ext);
+
+        // Process web targets before linux, since Emscripten canBuildOnHost(Linux) is true
+        // and would otherwise be consumed by the linux job
+        if (needsWeb) {
+            List<BuildTarget> webTargets = new ArrayList<>();
+            Iterator<BuildTarget> webIterator = allTargets.iterator();
+            while (webIterator.hasNext()) {
+                BuildTarget next = webIterator.next();
+                if (next.os == Os.Emscripten) {
+                    webTargets.add(next);
+                    webIterator.remove();
+                }
+            }
+            String webTemplateString = new FileDescriptor("com.badlogic.gdx.jnigen.gradle/web.yaml", FileDescriptor.FileType.Classpath).readString();
+            webTemplateString = injectJobs(webTemplateString, Os.Linux, webTargets);
+            jobs.add(webTemplateString);
+            jobsNeeded.add("build-web");
+
+            String downloadArtifactTemplate = new FileDescriptor("com.badlogic.gdx.jnigen.gradle/artifactdownload.yaml", FileDescriptor.FileType.Classpath).readString();
+            downloadArtifactTemplate = downloadArtifactTemplate.replace("%tasknameos%", "web");
+            artifactDownloads.add(downloadArtifactTemplate);
+        }
+
         if (needsLinux) {
             String linuxTemplateString = new FileDescriptor("com.badlogic.gdx.jnigen.gradle/linux.yaml", FileDescriptor.FileType.Classpath).readString();
             linuxTemplateString = injectJobs(linuxTemplateString, Os.Linux, allTargets);
@@ -140,6 +164,10 @@ public class GHABuilder {
 
     private boolean needsLinux (JnigenExtension ext) {
         return ext.targets.stream().anyMatch(it -> it.os == Os.Android || it.os == Os.Linux || (it.os == Os.Windows && it.compilerABIType == CompilerABIType.GCC_CLANG));
+    }
+
+    private boolean needsWeb (JnigenExtension ext) {
+        return ext.targets.stream().anyMatch(it -> it.os == Os.Emscripten);
     }
 
 }

--- a/compiling/gdx-jnigen-gradle/src/main/resources/com.badlogic.gdx.jnigen.gradle/web.yaml
+++ b/compiling/gdx-jnigen-gradle/src/main/resources/com.badlogic.gdx.jnigen.gradle/web.yaml
@@ -1,0 +1,29 @@
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+%steps%
+
+      - name: Pack artifacts
+        run: |
+          find .  -name "*.js" -o -name "*.wasm" | grep "libs" > native-files-list
+          zip natives-web -@ < native-files-list
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: natives-web.zip
+          path: natives-web.zip

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/BuildTarget.java
@@ -414,6 +414,23 @@ public class BuildTarget {
             return ios;
         }
 
+        if (osTarget == Os.Emscripten) {
+            // Emscripten WebAssembly
+            BuildTarget emscripten = new BuildTarget(Os.Emscripten, Architecture.Bitness._32, new String[]{""}, new String[0], new String[]{""},
+                    new String[0], new String[0], "", new String[]{"-c", "-O2", "-Wall", "-fmessage-length=0"},
+                    new String[]{"-c", "-O2", "-Wall", "-fmessage-length=0"},
+                    new String[]{"-s", "MODULARIZE=1", "-s", "ALLOW_MEMORY_GROWTH=1",
+                            "-s", "ALLOW_TABLE_GROWTH=1",
+                            "-s", "FORCE_FILESYSTEM=1",
+                            "-s", "WASM_BIGINT=1",
+                            "-s", "EXPORTED_RUNTIME_METHODS=['ccall','cwrap','addFunction','removeFunction','lengthBytesUTF8','stringToUTF8','FS']"}, null);
+            emscripten.cCompiler = "emcc";
+            emscripten.cppCompiler = "em++";
+            emscripten.architecture = Architecture.WASM;
+            emscripten.compilerABIType = CompilerABIType.EMSCRIPTEN;
+            return emscripten;
+        }
+
         throw new RuntimeException("Unknown target type");
     }
 
@@ -454,6 +471,11 @@ public class BuildTarget {
     }
 
     public boolean canBuildOnHost (Os hostOS) {
+        // Emscripten is a cross-compiler that can build on any desktop host
+        if (os == Os.Emscripten) {
+            return hostOS == Os.Windows || hostOS == Os.Linux || hostOS == Os.MacOsX;
+        }
+
         switch (hostOS) {
             case Windows:
                 //Android, Windows, WindowsMSCV
@@ -477,6 +499,7 @@ public class BuildTarget {
 
             case Android:
             case IOS:
+            case Emscripten:
                 return false;
             default:
                 throw new IllegalStateException("Unexpected value: " + hostOS);

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/NativeCodeGenerator.java
@@ -566,8 +566,14 @@ public class NativeCodeGenerator {
 		for (Argument arg : javaMethod.getArguments()) {
 			if (arg.getType().isString()) {
 				String type = "char*";
+				// On Emscripten, the jstring parameter is already a char* (WASM pointer),
+				// so we cast it directly instead of calling env->GetStringUTFChars().
+				buffer.append("#if defined(__EMSCRIPTEN__)\n");
+				buffer.append("\t" + type + " " + arg.getName() + " = (" + type + ")" + JNI_ARG_PREFIX + arg.getName() + ";\n");
+				buffer.append("#else\n");
 				buffer.append("\t" + type + " " + arg.getName() + " = (" + type + ")env->GetStringUTFChars(" + JNI_ARG_PREFIX
 					+ arg.getName() + ", 0);\n");
+				buffer.append("#endif\n");
 				additionalArgs.append(", ");
 				additionalArgs.append(type);
 				additionalArgs.append(" ");
@@ -582,8 +588,14 @@ public class NativeCodeGenerator {
 		for (Argument arg : javaMethod.getArguments()) {
 			if (arg.getType().isPrimitiveArray()) {
 				String type = arg.getType().getArrayCType();
+				// On Emscripten, the array parameter is already a WASM pointer,
+				// so we cast it directly instead of calling env->GetPrimitiveArrayCritical().
+				buffer.append("#if defined(__EMSCRIPTEN__)\n");
+				buffer.append("\t" + type + " " + arg.getName() + " = (" + type + ")" + JNI_ARG_PREFIX + arg.getName() + ";\n");
+				buffer.append("#else\n");
 				buffer.append("\t" + type + " " + arg.getName() + " = (" + type + ")env->GetPrimitiveArrayCritical(" + JNI_ARG_PREFIX
 					+ arg.getName() + ", 0);\n");
+				buffer.append("#endif\n");
 				additionalArgs.append(", ");
 				additionalArgs.append(type);
 				additionalArgs.append(" ");
@@ -598,18 +610,22 @@ public class NativeCodeGenerator {
 	}
 
 	private void emitJniCleanupCode (StringBuffer buffer, JavaMethod javaMethod, CMethod cMethod) {
-		// emit cleanup code for arrays, must come first
+		// emit cleanup code for arrays, must come first (skip on Emscripten — no JNI env)
 		for (Argument arg : javaMethod.getArguments()) {
 			if (arg.getType().isPrimitiveArray()) {
+				buffer.append("#if !defined(__EMSCRIPTEN__)\n");
 				buffer.append("\tenv->ReleasePrimitiveArrayCritical(" + JNI_ARG_PREFIX + arg.getName() + ", " + arg.getName()
 					+ ", 0);\n");
+				buffer.append("#endif\n");
 			}
 		}
 
-		// emit cleanup code for strings
+		// emit cleanup code for strings (skip on Emscripten — no JNI env)
 		for (Argument arg : javaMethod.getArguments()) {
 			if (arg.getType().isString()) {
+				buffer.append("#if !defined(__EMSCRIPTEN__)\n");
 				buffer.append("\tenv->ReleaseStringUTFChars(" + JNI_ARG_PREFIX + arg.getName() + ", " + arg.getName() + ");\n");
+				buffer.append("#endif\n");
 			}
 		}
 

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/PlatformBuilder.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/PlatformBuilder.java
@@ -118,6 +118,8 @@ public class PlatformBuilder {
                 return new GNUToolchain();
             case Android:
                 return new AndroidToolchain();
+            case Emscripten:
+                return new EmscriptenToolchain();
             default:
                 throw new IllegalStateException("Unexpected value: " + buildTarget.os);
         }
@@ -157,7 +159,9 @@ public class PlatformBuilder {
                 "mac/jni_md.h",
 
                 "win32/jawt_md.h",
-                "win32/jni_md.h"
+                "win32/jni_md.h",
+
+                "web/jni_md.h"
         };
 
         for (String file : files) {

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/Packager.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/Packager.java
@@ -54,6 +54,8 @@ public class Packager {
                 return new AndroidPackaging();
             case IOS:
                 return new IOSPackaging();
+            case Web:
+                return new WebPackaging();
             default:
                 throw new RuntimeException("Packaging for platform " + platform + " is not supported");
         }

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/WebPackaging.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/WebPackaging.java
@@ -5,9 +5,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 /**
  * Packages Emscripten .js and .wasm files into a natives-web.jar
@@ -35,8 +39,27 @@ public class WebPackaging extends PlatformPackager {
 
         File outputJar = new File(buildConfig.libsDir.file().getAbsoluteFile(), buildConfig.targetJarBaseName + "-natives-web.jar");
 
-        try {
-            Util.JarFiles(outputJar, targetBinaries, buildConfig.errorOnPackageMissingNative);
+        try (FileOutputStream fos = new FileOutputStream(outputJar);
+             JarOutputStream jarOutputStream = new JarOutputStream(fos)) {
+
+            for (File file : targetBinaries) {
+                if (!file.exists()) {
+                    if (buildConfig.errorOnPackageMissingNative) {
+                        throw new IOException("File not found when packaging: " + file);
+                    } else {
+                        logger.warn("File not found when packaging: {}", file);
+                        continue;
+                    }
+                }
+                jarOutputStream.putNextEntry(new JarEntry(file.getName()));
+                Files.copy(file.toPath(), jarOutputStream);
+                jarOutputStream.closeEntry();
+            }
+
+            // Add empty marker file so TeaVM plugin can discover this jar
+            jarOutputStream.putNextEntry(new JarEntry("META-INF/gdx-teavm.properties"));
+            jarOutputStream.closeEntry();
+
         } catch (IOException e) {
             logger.error("Exception when packing.", e);
             throw new RuntimeException(e);

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/WebPackaging.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/packaging/WebPackaging.java
@@ -1,0 +1,47 @@
+package com.badlogic.gdx.jnigen.build.packaging;
+
+import com.badlogic.gdx.jnigen.BuildTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Packages Emscripten .js and .wasm files into a natives-web.jar
+ */
+public class WebPackaging extends PlatformPackager {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebPackaging.class);
+
+    @Override
+    protected void packagePlatformImpl () {
+        List<File> targetBinaries = new ArrayList<>();
+        for (BuildTarget buildTarget : targetList) {
+            File jsFile = buildTarget.getTargetBinaryFile(buildConfig);
+            targetBinaries.add(jsFile);
+
+            // Also include the .wasm file that Emscripten generates alongside the .js file
+            String jsPath = jsFile.getAbsolutePath();
+            if (jsPath.endsWith(".js")) {
+                File wasmFile = new File(jsPath.substring(0, jsPath.length() - 3) + ".wasm");
+                if (wasmFile.exists()) {
+                    targetBinaries.add(wasmFile);
+                }
+            }
+        }
+
+        File outputJar = new File(buildConfig.libsDir.file().getAbsoluteFile(), buildConfig.targetJarBaseName + "-natives-web.jar");
+
+        try {
+            Util.JarFiles(outputJar, targetBinaries, buildConfig.errorOnPackageMissingNative);
+        } catch (IOException e) {
+            logger.error("Exception when packing.", e);
+            throw new RuntimeException(e);
+        }
+
+        logger.info("Packed web platform to {}", outputJar);
+    }
+}

--- a/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/EmscriptenToolchain.java
+++ b/compiling/gdx-jnigen/src/main/java/com/badlogic/gdx/jnigen/build/toolchains/EmscriptenToolchain.java
@@ -1,0 +1,178 @@
+package com.badlogic.gdx.jnigen.build.toolchains;
+
+import com.badlogic.gdx.jnigen.build.ToolFinder;
+import com.badlogic.gdx.jnigen.build.ToolchainExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Toolchain that compiles C/C++ to WebAssembly using Emscripten (emcc/em++).
+ */
+public class EmscriptenToolchain extends BaseToolchain {
+
+    private static final Logger logger = LoggerFactory.getLogger(EmscriptenToolchain.class);
+
+    private File cCompilerExecutable;
+    private File cppCompilerExecutable;
+
+    @Override
+    public void checkForTools () {
+        String cCompiler = target.cCompiler;
+        String cppCompiler = target.cppCompiler;
+
+        // Check EMSDK env var for additional PATH entries
+        String emsdk = System.getenv("EMSDK");
+        if (emsdk != null) {
+            String emsdkUpstream = emsdk + File.separator + "upstream" + File.separator + "emscripten";
+            String currentPath = System.getenv("PATH");
+            if (currentPath != null && !currentPath.contains(emsdkUpstream)) {
+                ENV.addToPath(emsdkUpstream);
+            }
+        }
+
+        cCompilerExecutable = ToolFinder.getToolFile(cCompiler, ENV, true);
+        cppCompilerExecutable = ToolFinder.getToolFile(cppCompiler, ENV, true);
+
+        logger.info("Emscripten toolchain is valid.\nemcc: {}\nem++: {}", cCompilerExecutable, cppCompilerExecutable);
+    }
+
+    @Override
+    public void collectCompilationTasks () {
+        collectCCompileTasks();
+        collectCPPCompileTasks();
+    }
+
+    private void collectCCompileTasks () {
+        if (buildCFiles.isEmpty()) {
+            logger.info("No c files, skipping c compilation");
+            return;
+        }
+
+        List<String> args = new ArrayList<>();
+        args.addAll(Arrays.asList(target.cFlags));
+
+        // Include JNI headers (web/jni_md.h provides Emscripten-compatible definitions)
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/"));
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/" + target.os.getJniPlatform()));
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "."));
+        for (String headerDir : target.headerDirs) {
+            args.add("-I" + convertToAbsoluteRelativeTo(config.projectDir, headerDir));
+        }
+
+        for (File buildCFile : buildCFiles) {
+            ArrayList<String> perFileArgs = new ArrayList<>(args);
+            perFileArgs.add(buildCFile.getAbsolutePath());
+            perFileArgs.add("-o");
+            perFileArgs.add(new File(buildDirectory, toObjectFile(buildCFile.getName())).getAbsolutePath());
+
+            compilationTasks.add(new Callable<Void>() {
+                @Override
+                public Void call () throws Exception {
+                    logger.info("Compiling C File (Emscripten) {}", buildCFile.getAbsolutePath());
+                    ToolchainExecutor.execute(cCompilerExecutable, config.jniDir.file(), perFileArgs, createToolChainCallback("Emscripten C Compile - " + buildCFile.getName()));
+                    return null;
+                }
+            });
+        }
+    }
+
+    private void collectCPPCompileTasks () {
+        if (buildCppFiles.isEmpty()) {
+            logger.info("No cpp files, skipping cpp compilation");
+            return;
+        }
+
+        List<String> args = new ArrayList<>();
+        args.addAll(Arrays.asList(target.cppFlags));
+
+        // Include JNI headers (web/jni_md.h provides Emscripten-compatible definitions)
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/"));
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "jni-headers/" + target.os.getJniPlatform()));
+        args.add("-I" + convertToAbsoluteRelativeTo(config.jniDir, "."));
+        for (String headerDir : target.headerDirs) {
+            args.add("-I" + convertToAbsoluteRelativeTo(config.projectDir, headerDir));
+        }
+
+        for (File buildCppFile : buildCppFiles) {
+            ArrayList<String> perFileArgs = new ArrayList<>(args);
+            perFileArgs.add(buildCppFile.getAbsolutePath());
+            perFileArgs.add("-o");
+            perFileArgs.add(new File(buildDirectory, toObjectFile(buildCppFile.getName())).getAbsolutePath());
+
+            compilationTasks.add(new Callable<Void>() {
+                @Override
+                public Void call () throws Exception {
+                    logger.info("Compiling CPP File (Emscripten) {}", buildCppFile.getAbsolutePath());
+                    ToolchainExecutor.execute(cppCompilerExecutable, config.jniDir.file(), perFileArgs, createToolChainCallback("Emscripten CPP Compile - " + buildCppFile.getName()));
+                    return null;
+                }
+            });
+        }
+    }
+
+    private String toObjectFile (String name) {
+        String[] split = name.split("\\.");
+        return split[0] + ".o";
+    }
+
+    @Override
+    public void link () {
+        libsDirectory.mkdirs();
+        if (!libsDirectory.exists()) {
+            logger.error("Error creating libs dir {}", libsDirectory.getAbsolutePath());
+            throw new RuntimeException("Error creating libs dir");
+        }
+
+        ArrayList<File> objFiles = new ArrayList<>();
+        for (File cObjectFile : buildCFiles) {
+            objFiles.add(new File(buildDirectory, toObjectFile(cObjectFile.getName())));
+        }
+        for (File cppObjectFile : buildCppFiles) {
+            objFiles.add(new File(buildDirectory, toObjectFile(cppObjectFile.getName())));
+        }
+
+        List<String> args = new ArrayList<>();
+
+        // Add linker flags (contains Emscripten-specific -s flags)
+        args.addAll(Arrays.asList(target.linkerFlags));
+
+        // Generate a unique EXPORT_NAME based on the shared library name to avoid
+        // clashes when multiple jnigen libraries are loaded on the same page
+        String exportName = "createModule_" + sanitizeForJs(config.sharedLibName);
+        args.add("-sEXPORT_NAME=" + exportName);
+        logger.info("Using Emscripten EXPORT_NAME={}", exportName);
+
+        args.add("-o");
+        args.add(targetLibFile.getAbsolutePath());
+
+        for (File objFile : objFiles) {
+            args.add(objFile.getAbsolutePath());
+        }
+
+        args.addAll(Arrays.asList(target.libraries));
+
+        // Use emcc for linking (handles both C and C++ object files)
+        ToolchainExecutor.execute(cppCompilerExecutable, config.buildDir.file(), args, createToolChainCallback("Emscripten Link"));
+    }
+
+    /**
+     * Sanitizes a library name into a valid JavaScript identifier suffix.
+     * Replaces non-alphanumeric characters with underscores.
+     */
+    private static String sanitizeForJs (String name) {
+        return name.replaceAll("[^a-zA-Z0-9]", "_");
+    }
+
+    @Override
+    public void strip () {
+        // Emscripten handles optimization/stripping via -O flags during compilation and linking.
+        // No separate strip step needed.
+        logger.info("Skipping strip for Emscripten (handled by optimization level)");
+    }
+}

--- a/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/headers/jnigen-web.h
+++ b/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/headers/jnigen-web.h
@@ -1,0 +1,63 @@
+/**
+ * JNI compatibility shim for Emscripten/WebAssembly builds.
+ *
+ * Provides JNI-like type definitions so that code written for JNI
+ * can compile under Emscripten without modification.
+ */
+
+#ifndef JNIGEN_WEB_H
+#define JNIGEN_WEB_H
+
+#include <emscripten.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* JNI primitive type mappings */
+typedef int8_t   jbyte;
+typedef int16_t  jshort;
+typedef int32_t  jint;
+typedef int64_t  jlong;
+typedef float    jfloat;
+typedef double   jdouble;
+typedef uint8_t  jboolean;
+typedef uint16_t jchar;
+typedef jint     jsize;
+
+/* JNI reference types - opaque pointers on web */
+typedef void*    jobject;
+typedef void*    jclass;
+typedef void*    jstring;
+typedef void*    jarray;
+typedef void*    jbyteArray;
+typedef void*    jshortArray;
+typedef void*    jintArray;
+typedef void*    jlongArray;
+typedef void*    jfloatArray;
+typedef void*    jdoubleArray;
+typedef void*    jbooleanArray;
+typedef void*    jcharArray;
+typedef void*    jobjectArray;
+typedef void*    jthrowable;
+typedef void*    jweak;
+typedef void*    jmethodID;
+typedef void*    jfieldID;
+
+/* JNIEnv is not used in Emscripten builds */
+typedef void*    JNIEnv;
+typedef void*    JavaVM;
+
+/* Export/calling convention macros */
+#define JNIEXPORT EMSCRIPTEN_KEEPALIVE
+#define JNICALL
+#define JNIIMPORT
+
+/* JNI boolean constants */
+#define JNI_TRUE  1
+#define JNI_FALSE 0
+
+/* No-op macros for JNI env handling */
+#define JNI_OnLoad(vm, reserved) __attribute__((unused)) static int _jni_onload_unused
+#define JNI_OnUnload(vm, reserved) __attribute__((unused)) static int _jni_onunload_unused
+
+#endif /* JNIGEN_WEB_H */

--- a/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/headers/web/jni_md.h
+++ b/compiling/gdx-jnigen/src/main/resources/com/badlogic/gdx/jnigen/resources/headers/web/jni_md.h
@@ -1,0 +1,18 @@
+/*
+ * JNI platform-specific definitions for Emscripten/WebAssembly.
+ */
+
+#ifndef _JAVASOFT_JNI_MD_H_
+#define _JAVASOFT_JNI_MD_H_
+
+#include <emscripten.h>
+
+#define JNIEXPORT EMSCRIPTEN_KEEPALIVE
+#define JNIIMPORT
+#define JNICALL
+
+typedef int jint;
+typedef long long jlong;
+typedef signed char jbyte;
+
+#endif /* !_JAVASOFT_JNI_MD_H_ */

--- a/gdx-jnigen-loader/build.gradle
+++ b/gdx-jnigen-loader/build.gradle
@@ -1,5 +1,5 @@
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 dependencies {
     api "com.badlogicgames.jnigen:jnigen-commons"

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -89,6 +89,8 @@ public class SharedLibraryLoader {
 	public void load (String libraryName) {
 		// in case of iOS, it's unnecessary to dlopen
 		if (HostDetection.os == Os.IOS) return;
+		// in case of Emscripten/Web, native loading is handled by the WASM module
+		if (HostDetection.os == Os.Emscripten) return;
 
 		synchronized (SharedLibraryLoader.class) {
 			if (isLoaded(libraryName)) return;

--- a/gdx-jnigen-runtime-gwt/build.gradle
+++ b/gdx-jnigen-runtime-gwt/build.gradle
@@ -1,0 +1,13 @@
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    compileOnly "com.google.gwt:gwt-user:2.10.0"
+    compileOnly project(":jnigen-runtime")
+}
+
+eclipse {
+    project {
+        name = "gdx-jnigen-runtime-gwt"
+    }
+}

--- a/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/JnigenGwt.gwt.xml
+++ b/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/JnigenGwt.gwt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module>
+    <inherits name="com.google.gwt.core.Core"/>
+    <source path="emu"/>
+    <super-source path="emu"/>
+</module>

--- a/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/emu/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/emu/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -1,0 +1,25 @@
+package com.badlogic.gdx.jnigen.loader;
+
+/**
+ * GWT emulation of SharedLibraryLoader.
+ * On web, native libraries are loaded as WASM modules by the host page, not by Java code.
+ */
+public class SharedLibraryLoader {
+
+    public SharedLibraryLoader() {
+    }
+
+    public SharedLibraryLoader(String nativesJar) {
+    }
+
+    public void load(String libraryName) {
+        // No-op on web - WASM module is loaded by the host page / JS bootstrap
+    }
+
+    static public synchronized void setLoaded(String libraryName) {
+    }
+
+    static public synchronized boolean isLoaded(String libraryName) {
+        return true;
+    }
+}

--- a/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/emu/com/badlogic/gdx/jnigen/runtime/CHandler.java
+++ b/gdx-jnigen-runtime-gwt/src/main/java/com/badlogic/gdx/jnigen/gwt/emu/com/badlogic/gdx/jnigen/runtime/CHandler.java
@@ -1,0 +1,157 @@
+package com.badlogic.gdx.jnigen.runtime;
+
+import com.badlogic.gdx.jnigen.runtime.c.CTypeInfo;
+import com.badlogic.gdx.jnigen.runtime.c.CXXException;
+import com.badlogic.gdx.jnigen.runtime.closure.Closure;
+import com.badlogic.gdx.jnigen.runtime.closure.ClosureObject;
+import com.badlogic.gdx.jnigen.runtime.closure.ClosureDecoder;
+import com.badlogic.gdx.jnigen.runtime.util.DowncallCClosureObjectSupplier;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+/**
+ * GWT emulation of CHandler. Delegates to Emscripten WASM Module via JSNI.
+ * <p>
+ * WASM is 32-bit, so all pointer values are int-width.
+ * Web is single-threaded, so synchronized blocks are no-ops.
+ */
+public class CHandler {
+
+    public static final int POINTER_SIZE = 4;
+    public static final boolean IS_32_BIT = true;
+    public static final boolean IS_64_BIT = false;
+    public static final boolean IS_COMPILED_UNIX = false;
+    public static final boolean IS_COMPILED_WIN = false;
+    public static final boolean IS_COMPILED_ANDROID_X86 = false;
+    public static final boolean IS_CHAR_SIGNED = true;
+    public static final int LONG_SIZE = 4;
+
+    private static final HashMap<Long, ClosureObject<?>> fnPtrClosureMap = new HashMap<>();
+
+    public static void init() {
+        // No-op on web - WASM module must be loaded by the host page
+    }
+
+    public static String getExceptionString(Throwable e) {
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
+    }
+
+    public static <T extends Closure> void dispatchCallback(ClosureDecoder<T> toCallOn, long parameter) {
+        // Web closures dispatch differently via JS function pointers
+        throw new UnsupportedOperationException("dispatchCallback not supported on web - use JS function pointers");
+    }
+
+    public static CTypeInfo constructCTypeFromNativeType(long nativeType) {
+        throw new UnsupportedOperationException("constructCTypeFromNativeType not available on web");
+    }
+
+    public static long getFFICifForSignature(CTypeInfo[] signature) {
+        // No libffi on web - signatures are known at generation time
+        return 0;
+    }
+
+    public static <T extends Closure> ClosureObject<T> createClosureForObject(T object) {
+        throw new UnsupportedOperationException("createClosureForObject not yet implemented for web");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Closure> ClosureObject<T> getClosureObject(long fnPtr, DowncallCClosureObjectSupplier<T> closureFallback) {
+        ClosureObject<T> closureObject = (ClosureObject<T>) fnPtrClosureMap.get(fnPtr);
+        if (closureObject == null) {
+            if (closureFallback == null)
+                throw new RuntimeException("No Closure object found for " + fnPtr);
+            closureObject = closureFallback.get(fnPtr);
+            fnPtrClosureMap.put(fnPtr, closureObject);
+        }
+        return closureObject;
+    }
+
+    public static void deregisterFunctionPointer(long fnPtr) {
+        fnPtrClosureMap.remove(fnPtr);
+    }
+
+    public static void clearRegisteredFunctionPointer() {
+        fnPtrClosureMap.clear();
+    }
+
+    public static native void setDisableCXXExceptionMessage(boolean disable) /*-{
+        // No-op on web
+    }-*/;
+
+    public static native boolean reExportSymbolsGlobally(String libPath) /*-{
+        return false;
+    }-*/;
+
+    public static native void dispatchCCall(long fnPtr, long cif, long parameter) /*-{
+        // Direct function dispatch - the generator emits specific calls instead
+    }-*/;
+
+    public static native long convertNativeTypeToFFIType(long nativeType) /*-{
+        return 0;
+    }-*/;
+
+    public static native long createClosureForObject(long cifArg, Object object, long closureRet) /*-{
+        return 0;
+    }-*/;
+
+    public static native ByteBuffer wrapPointer(long pointer, int size) /*-{
+        return null;
+    }-*/;
+
+    public static native int getSizeFromFFIType(long type) /*-{
+        return 0;
+    }-*/;
+
+    public static native void freeClosure(long closurePtr) /*-{
+        if ($wnd.Module && $wnd.Module.removeFunction) {
+            $wnd.Module.removeFunction(closurePtr);
+        }
+    }-*/;
+
+    public static native long malloc(long size) /*-{
+        if ($wnd.Module && $wnd.Module._malloc) {
+            return $wnd.Module._malloc(size);
+        }
+        return 0;
+    }-*/;
+
+    public static native long calloc(long count, long size) /*-{
+        if ($wnd.Module && $wnd.Module._calloc) {
+            return $wnd.Module._calloc(count, size);
+        }
+        var total = count * size;
+        var ptr = $wnd.Module._malloc(total);
+        if (ptr) {
+            $wnd.Module.HEAPU8.fill(0, ptr, ptr + total);
+        }
+        return ptr;
+    }-*/;
+
+    public static native void free(long pointer) /*-{
+        if ($wnd.Module && $wnd.Module._free) {
+            $wnd.Module._free(pointer);
+        }
+    }-*/;
+
+    public static native void memcpy(long dst, long src, long size) /*-{
+        if ($wnd.Module && $wnd.Module.HEAPU8) {
+            $wnd.Module.HEAPU8.copyWithin(dst, src, src + size);
+        }
+    }-*/;
+
+    public static native long clone(long src, long size) /*-{
+        if ($wnd.Module) {
+            var dst = $wnd.Module._malloc(size);
+            if (dst) {
+                $wnd.Module.HEAPU8.copyWithin(dst, src, src + size);
+            }
+            return dst;
+        }
+        return 0;
+    }-*/;
+}

--- a/gdx-jnigen-runtime-teavm/build.gradle
+++ b/gdx-jnigen-runtime-teavm/build.gradle
@@ -1,0 +1,14 @@
+sourceCompatibility = 11
+targetCompatibility = 11
+
+dependencies {
+    compileOnly "org.teavm:teavm-jso:0.13.1"
+    compileOnly "org.teavm:teavm-core:0.13.1"
+    compileOnly project(":jnigen-runtime")
+}
+
+eclipse {
+    project {
+        name = "gdx-jnigen-runtime-teavm"
+    }
+}

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/CHandlerTransformer.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/CHandlerTransformer.java
@@ -1,0 +1,193 @@
+package com.badlogic.gdx.jnigen.teavm;
+
+import org.teavm.model.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * TeaVM class transformer that automatically provides JavaScript implementations
+ * for JNI native methods by routing them to Emscripten-exported functions.
+ * <p>
+ * For each native method found in user/library classes (not platform classes),
+ * this transformer adds a {@code @GeneratedBy(JniMethodGenerator.class)} annotation.
+ * At code generation time, {@link JniMethodGenerator} emits JavaScript that calls
+ * {@code Module._Java_package_Class_method(0, 0, args...)}.
+ * <p>
+ * Special handling:
+ * <ul>
+ *   <li>{@code SharedLibraryLoader.load()} — made into a no-op</li>
+ * </ul>
+ */
+public class CHandlerTransformer implements ClassHolderTransformer {
+
+    private static final String JNIGEN_SHARED_LIB_LOADER = "com.badlogic.gdx.jnigen.loader.SharedLibraryLoader";
+    private static final String LIBGDX_SHARED_LIB_LOADER = "com.badlogic.gdx.utils.SharedLibraryLoader";
+    private static final String GENERATED_BY_ANNOTATION = "org.teavm.backend.javascript.spi.GeneratedBy";
+    private static final String JSBODY_ANNOTATION = "org.teavm.jso.JSBody";
+
+    /** Packages whose native methods are provided by the platform/runtime, not JNI. */
+    private static final String[] SKIP_PREFIXES = {
+            "java.", "javax.", "sun.", "jdk.", "com.sun.",
+            "org.teavm.", "org.w3c.", "org.xml.",
+            "com.badlogic.gdx.jnigen.teavm.",
+            "com.badlogic.gdx.jnigen.runtime."
+    };
+
+    @Override
+    public void transformClass (ClassHolder cls, ClassHolderTransformerContext context) {
+        String className = cls.getName();
+
+        // Make SharedLibraryLoader.load() a no-op — on web, WASM modules are
+        // loaded via <script> tags before the app starts, not at runtime.
+        // Handle both jnigen's and libGDX's SharedLibraryLoader.
+        if (className.equals(JNIGEN_SHARED_LIB_LOADER) || className.equals(LIBGDX_SHARED_LIB_LOADER)) {
+            makeLoadNoOp(cls);
+            return;
+        }
+
+        // Skip platform/runtime classes — their native methods are handled by TeaVM itself
+        if (shouldSkip(className)) {
+            return;
+        }
+
+        transformNativeMethods(cls);
+    }
+
+    private boolean shouldSkip (String className) {
+        for (String prefix : SKIP_PREFIXES) {
+            if (className.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void makeLoadNoOp (ClassHolder cls) {
+        for (MethodHolder method : cls.getMethods()) {
+            if (method.getName().equals("load")) {
+                makeVoidNoOp(method);
+            }
+        }
+    }
+
+    private void makeVoidNoOp (MethodHolder method) {
+        method.getModifiers().remove(ElementModifier.NATIVE);
+        Program program = new Program();
+        BasicBlock block = program.createBasicBlock();
+
+        int varCount = method.parameterCount() + (method.hasModifier(ElementModifier.STATIC) ? 0 : 1);
+        for (int i = 0; i < varCount; i++) {
+            program.createVariable();
+        }
+
+        block.add(new org.teavm.model.instructions.ExitInstruction());
+        method.setProgram(program);
+    }
+
+    private void transformNativeMethods (ClassHolder cls) {
+        for (MethodHolder method : cls.getMethods()) {
+            if (method.hasModifier(ElementModifier.NATIVE)
+                    && method.getAnnotations().get(JSBODY_ANNOTATION) == null
+                    && method.getAnnotations().get(GENERATED_BY_ANNOTATION) == null) {
+                addGeneratedByAnnotation(method);
+            }
+        }
+    }
+
+    /**
+     * Add @GeneratedBy(JniMethodGenerator.class) to a native method.
+     * The method stays native — JniMethodGenerator will emit the JavaScript
+     * implementation during code generation.
+     */
+    private void addGeneratedByAnnotation (MethodHolder method) {
+        AnnotationHolder generatedBy = new AnnotationHolder(GENERATED_BY_ANNOTATION);
+        generatedBy.getValues().put("value",
+                new AnnotationValue(ValueType.object(JniMethodGenerator.class.getName())));
+        method.getAnnotations().add(generatedBy);
+    }
+
+    // ---- JNI Name Mangling (package-private for use by JniMethodGenerator) ----
+
+    /**
+     * Compute the JNI-mangled export function name for a native method.
+     * <p>
+     * For non-overloaded methods: {@code Java_package_Class_method}
+     * For overloaded methods: {@code Java_package_Class_method__signature}
+     */
+    static String computeJniName (String className, String methodName,
+                                   MethodDescriptor descriptor, boolean isOverloaded) {
+        StringBuilder sb = new StringBuilder("Java_");
+        // Mangle each package/class component individually, then join with '_'.
+        // The '_' separators (from '.') must NOT be mangled — only original '_'
+        // within identifiers get replaced with '_1'.
+        String[] parts = className.split("\\.");
+        for (int i = 0; i < parts.length; i++) {
+            if (i > 0) sb.append('_');
+            sb.append(mangleJniComponent(parts[i]));
+        }
+        sb.append('_');
+        sb.append(mangleJniComponent(methodName));
+
+        if (isOverloaded) {
+            sb.append("__");
+            for (int i = 0; i < descriptor.parameterCount(); i++) {
+                appendJniTypeSignature(sb, descriptor.parameterType(i));
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Mangle a JNI name component: replace _ with _1, ; with _2, [ with _3
+     */
+    private static String mangleJniComponent (String s) {
+        StringBuilder sb = new StringBuilder(s.length());
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '_':
+                    sb.append("_1");
+                    break;
+                case ';':
+                    sb.append("_2");
+                    break;
+                case '[':
+                    sb.append("_3");
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Append the JNI type signature character(s) for a ValueType.
+     */
+    private static void appendJniTypeSignature (StringBuilder sb, ValueType type) {
+        if (type instanceof ValueType.Primitive) {
+            switch (((ValueType.Primitive) type).getKind()) {
+                case BOOLEAN: sb.append('Z'); break;
+                case BYTE: sb.append('B'); break;
+                case CHARACTER: sb.append('C'); break;
+                case SHORT: sb.append('S'); break;
+                case INTEGER: sb.append('I'); break;
+                case LONG: sb.append('J'); break;
+                case FLOAT: sb.append('F'); break;
+                case DOUBLE: sb.append('D'); break;
+            }
+        } else if (type instanceof ValueType.Object) {
+            String name = ((ValueType.Object) type).getClassName().replace('.', '/');
+            sb.append('L');
+            sb.append(mangleJniComponent(name.replace('/', '_')));
+            sb.append("_2"); // mangled ';'
+        } else if (type instanceof ValueType.Array) {
+            sb.append("_3"); // mangled '['
+            appendJniTypeSignature(sb, ((ValueType.Array) type).getItemType());
+        }
+    }
+}

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/CHandlerWeb.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/CHandlerWeb.java
@@ -1,0 +1,49 @@
+package com.badlogic.gdx.jnigen.teavm;
+
+import org.teavm.jso.JSBody;
+
+/**
+ * TeaVM bridge to Emscripten WASM Module.
+ * <p>
+ * All methods are static with {@code @JSBody} annotations that call into the
+ * Emscripten Module object. Pointer types are narrowed to {@code int} since
+ * WASM has a 32-bit address space.
+ */
+public final class CHandlerWeb {
+
+    private CHandlerWeb() {
+    }
+
+    @JSBody(params = {"size"}, script = "return Module._malloc(size);")
+    public static native int malloc(int size);
+
+    @JSBody(params = {"count", "size"}, script = "return Module._calloc(count, size);")
+    public static native int calloc(int count, int size);
+
+    @JSBody(params = {"ptr"}, script = "Module._free(ptr);")
+    public static native void free(int ptr);
+
+    @JSBody(params = {"dst", "src", "size"}, script = "Module.HEAPU8.copyWithin(dst, src, src + size);")
+    public static native void memcpy(int dst, int src, int size);
+
+    @JSBody(params = {"src", "size"}, script = ""
+            + "var dst = Module._malloc(size);"
+            + "Module.HEAPU8.copyWithin(dst, src, src + size);"
+            + "return dst;")
+    public static native int clone(int src, int size);
+
+    @JSBody(params = {"fnPtr"}, script = "Module.removeFunction(fnPtr);")
+    public static native void freeClosure(int fnPtr);
+
+    @JSBody(params = {"jsCallback", "signature"}, script = "return Module.addFunction(jsCallback, signature);")
+    public static native int addFunction(Object jsCallback, String signature);
+
+    @JSBody(params = {"fnPtr"}, script = "Module.removeFunction(fnPtr);")
+    public static native void removeFunction(int fnPtr);
+
+    @JSBody(params = {}, script = "return 4;")
+    public static native int getPointerSize();
+
+    @JSBody(params = {}, script = "return true;")
+    public static native boolean is32Bit();
+}

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/JniMethodGenerator.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/JniMethodGenerator.java
@@ -1,0 +1,201 @@
+package com.badlogic.gdx.jnigen.teavm;
+
+import org.teavm.backend.javascript.codegen.SourceWriter;
+import org.teavm.backend.javascript.spi.Generator;
+import org.teavm.backend.javascript.spi.GeneratorContext;
+import org.teavm.model.ClassReader;
+import org.teavm.model.ElementModifier;
+import org.teavm.model.MethodDescriptor;
+import org.teavm.model.MethodReader;
+import org.teavm.model.MethodReference;
+import org.teavm.model.PrimitiveType;
+import org.teavm.model.ValueType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * TeaVM code generator that emits JavaScript calling Emscripten-exported JNI functions.
+ * <p>
+ * For a native method like {@code MiniAudio.jniInitContext(int, short, boolean)},
+ * this generator emits:
+ * <pre>
+ * return Module._Java_games_rednblack_miniaudio_MiniAudio_jniInitContext(0, 0, p1, p2, p3);
+ * </pre>
+ * The first two zero arguments replace JNIEnv* and jclass/jobject.
+ * <p>
+ * Special handling:
+ * <ul>
+ *   <li>{@code long} params: wrapped with {@code Number()} (TeaVM BigInt → JS number)</li>
+ *   <li>{@code long} return: wrapped with {@code BigInt()} (JS number → TeaVM BigInt)</li>
+ *   <li>{@code String} params: allocated into WASM linear memory as UTF-8, freed after call</li>
+ * </ul>
+ */
+public class JniMethodGenerator implements Generator {
+
+    @Override
+    public void generate (GeneratorContext context, SourceWriter writer, MethodReference methodRef) {
+        // Determine if method is static or instance
+        ClassReader cls = context.getClassSource().get(methodRef.getClassName());
+        MethodReader method = cls != null ? cls.getMethod(methodRef.getDescriptor()) : null;
+        boolean isStatic = method != null && method.hasModifier(ElementModifier.STATIC);
+
+        // Compute JNI-mangled export name
+        // Check for overloaded native methods. A method is considered a JNI native if it
+        // is still marked NATIVE or has already been annotated with @GeneratedBy(JniMethodGenerator).
+        boolean isOverloaded = false;
+        if (cls != null) {
+            int count = 0;
+            for (MethodReader m : cls.getMethods()) {
+                if (m.getName().equals(methodRef.getName())
+                        && (m.hasModifier(ElementModifier.NATIVE) || m.getAnnotations().get("org.teavm.backend.javascript.spi.GeneratedBy") != null)) {
+                    count++;
+                }
+            }
+            isOverloaded = count > 1;
+        }
+
+        String jniName = CHandlerTransformer.computeJniName(
+                methodRef.getClassName(), methodRef.getName(), methodRef.getDescriptor(), isOverloaded);
+
+        MethodDescriptor descriptor = methodRef.getDescriptor();
+        ValueType resultType = descriptor.getResultType();
+        boolean hasReturn = resultType != ValueType.VOID;
+        boolean returnsLong = isLongType(resultType);
+        int paramCount = methodRef.parameterCount();
+
+        // Identify String parameters that need WASM memory allocation
+        List<Integer> stringParamIndices = new ArrayList<>();
+        for (int i = 0; i < paramCount; i++) {
+            if (isStringType(descriptor.parameterType(i))) {
+                stringParamIndices.add(i);
+            }
+        }
+
+        // Identify primitive array parameters that need WASM memory allocation
+        List<Integer> arrayParamIndices = new ArrayList<>();
+        for (int i = 0; i < paramCount; i++) {
+            if (isPrimitiveArrayType(descriptor.parameterType(i))) {
+                arrayParamIndices.add(i);
+            }
+        }
+
+        // For String params: convert TeaVM string to JS string, allocate WASM memory and write UTF-8 bytes
+        for (int idx : stringParamIndices) {
+            String paramName = context.getParameterName(idx + 1);
+            String ptrVar = "_s" + idx;
+            String jsStrVar = "_js" + idx;
+            // Convert TeaVM string object to native JS string via $rt_ustr()
+            writer.append("var ").append(ptrVar).append(" = 0;").softNewLine();
+            writer.append("if (").append(paramName).append(" !== null) {").indent().softNewLine();
+            writer.append("var ").append(jsStrVar).append(" = $rt_ustr(").append(paramName).append(");").softNewLine();
+            writer.append("var _len" + idx + " = Module.lengthBytesUTF8(").append(jsStrVar).append(") + 1;").softNewLine();
+            writer.append(ptrVar).append(" = Module._malloc(_len" + idx + ");").softNewLine();
+            writer.append("Module.stringToUTF8(").append(jsStrVar).append(", ").append(ptrVar).append(", _len" + idx + ");").softNewLine();
+            writer.outdent().append("}").softNewLine();
+        }
+
+        // For primitive array params: copy TeaVM array data into WASM linear memory
+        for (int idx : arrayParamIndices) {
+            String paramName = context.getParameterName(idx + 1);
+            String ptrVar = "_a" + idx;
+            String bufVar = "_buf" + idx;
+            writer.append("var ").append(ptrVar).append(" = 0;").softNewLine();
+            writer.append("if (").append(paramName).append(" !== null) {").indent().softNewLine();
+            writer.append("var ").append(bufVar).append(" = ").append(paramName).append(".data;").softNewLine();
+            writer.append(ptrVar).append(" = Module._malloc(").append(bufVar).append(".byteLength);").softNewLine();
+            writer.append("Module.HEAPU8.set(new Uint8Array(").append(bufVar).append(".buffer, ")
+                    .append(bufVar).append(".byteOffset, ").append(bufVar).append(".byteLength), ")
+                    .append(ptrVar).append(");").softNewLine();
+            writer.outdent().append("}").softNewLine();
+        }
+
+        boolean needsTryFinally = !stringParamIndices.isEmpty() || !arrayParamIndices.isEmpty();
+
+        if (needsTryFinally) {
+            writer.append("try {").indent().softNewLine();
+        }
+
+        // Emit: [var _r = ] [BigInt](Module._Java_...(0, 0, p1, p2, ...));
+        if (hasReturn) {
+            if (needsTryFinally) {
+                writer.append("var _r = ");
+            } else {
+                writer.append("return ");
+            }
+        }
+        // With WASM_BIGINT enabled, i64 (jlong) params are passed/returned as native BigInt.
+        // TeaVM already represents Java long as BigInt, so no conversion needed for long params.
+        // env (JNIEnv*) and obj (jclass/jobject) are i32 pointers, passed as 0.
+        writer.append("Module._").append(jniName).append("(0,").ws().append("0");
+
+        // Parameters: jstring → i32 (WASM pointer), jlong → i64 (BigInt),
+        // primitive array → i32 (WASM pointer), others → i32
+        for (int i = 0; i < paramCount; i++) {
+            writer.append(",").ws();
+            if (stringParamIndices.contains(i)) {
+                // Pass the WASM pointer (i32) instead of the JS string
+                writer.append("_s" + i);
+            } else if (arrayParamIndices.contains(i)) {
+                // Pass the WASM pointer (i32) instead of the array object
+                writer.append("_a" + i);
+            } else {
+                writer.append(context.getParameterName(i + 1));
+            }
+        }
+        writer.append(")");
+        writer.append(";").softNewLine();
+
+        if (needsTryFinally) {
+            // Copy modified array data back from WASM memory into Java arrays
+            // (matches JNI ReleasePrimitiveArrayCritical semantics with mode 0)
+            for (int idx : arrayParamIndices) {
+                String paramName = context.getParameterName(idx + 1);
+                String ptrVar = "_a" + idx;
+                String bufVar = "_buf" + idx;
+                writer.append("if (").append(ptrVar).append(") {").indent().softNewLine();
+                writer.append(bufVar).append(".set(new ").append(bufVar).append(".constructor(")
+                        .append("Module.HEAPU8.buffer, ").append(ptrVar).append(", ")
+                        .append(bufVar).append(".length));").softNewLine();
+                writer.outdent().append("}").softNewLine();
+            }
+            if (hasReturn) {
+                writer.append("return _r;").softNewLine();
+            }
+            writer.outdent().append("} finally {").indent().softNewLine();
+            // Free allocated strings
+            for (int idx : stringParamIndices) {
+                String ptrVar = "_s" + idx;
+                writer.append("if (").append(ptrVar).append(") Module._free(").append(ptrVar).append(");").softNewLine();
+            }
+            // Free allocated arrays
+            for (int idx : arrayParamIndices) {
+                String ptrVar = "_a" + idx;
+                writer.append("if (").append(ptrVar).append(") Module._free(").append(ptrVar).append(");").softNewLine();
+            }
+            writer.outdent().append("}").softNewLine();
+        }
+    }
+
+    private static boolean isLongType (ValueType type) {
+        if (type instanceof ValueType.Primitive) {
+            return ((ValueType.Primitive) type).getKind() == PrimitiveType.LONG;
+        }
+        return false;
+    }
+
+    private static boolean isStringType (ValueType type) {
+        if (type instanceof ValueType.Object) {
+            return "java.lang.String".equals(((ValueType.Object) type).getClassName());
+        }
+        return false;
+    }
+
+    private static boolean isPrimitiveArrayType (ValueType type) {
+        if (type instanceof ValueType.Array) {
+            ValueType itemType = ((ValueType.Array) type).getItemType();
+            return itemType instanceof ValueType.Primitive;
+        }
+        return false;
+    }
+}

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/JniMethodGenerator.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/JniMethodGenerator.java
@@ -88,7 +88,7 @@ public class JniMethodGenerator implements Generator {
             // Convert TeaVM string object to native JS string via $rt_ustr()
             writer.append("var ").append(ptrVar).append(" = 0;").softNewLine();
             writer.append("if (").append(paramName).append(" !== null) {").indent().softNewLine();
-            writer.append("var ").append(jsStrVar).append(" = $rt_ustr(").append(paramName).append(");").softNewLine();
+            writer.append("var ").append(jsStrVar).append(" = ").appendFunction("$rt_ustr").append("(").append(paramName).append(");").softNewLine();
             writer.append("var _len" + idx + " = Module.lengthBytesUTF8(").append(jsStrVar).append(") + 1;").softNewLine();
             writer.append(ptrVar).append(" = Module._malloc(_len" + idx + ");").softNewLine();
             writer.append("Module.stringToUTF8(").append(jsStrVar).append(", ").append(ptrVar).append(", _len" + idx + ");").softNewLine();

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/TeaVMJnigenPlugin.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/TeaVMJnigenPlugin.java
@@ -1,0 +1,18 @@
+package com.badlogic.gdx.jnigen.teavm;
+
+import org.teavm.vm.spi.TeaVMHost;
+import org.teavm.vm.spi.TeaVMPlugin;
+
+/**
+ * TeaVM plugin that registers the class transformer for substituting
+ * CHandler native methods with web-compatible implementations.
+ * <p>
+ * This plugin is discovered via {@code META-INF/services/org.teavm.vm.spi.TeaVMPlugin}.
+ */
+public class TeaVMJnigenPlugin implements TeaVMPlugin {
+
+    @Override
+    public void install(TeaVMHost host) {
+        host.add(new CHandlerTransformer());
+    }
+}

--- a/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/WasmMemory.java
+++ b/gdx-jnigen-runtime-teavm/src/main/java/com/badlogic/gdx/jnigen/teavm/WasmMemory.java
@@ -1,0 +1,71 @@
+package com.badlogic.gdx.jnigen.teavm;
+
+import org.teavm.jso.JSBody;
+
+/**
+ * Utilities for accessing WASM linear memory via Emscripten's typed array views.
+ */
+public final class WasmMemory {
+
+    private WasmMemory() {
+    }
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAP8[ptr];")
+    public static native byte getByte(int ptr);
+
+    @JSBody(params = {"ptr", "value"}, script = "Module.HEAP8[ptr] = value;")
+    public static native void setByte(int ptr, byte value);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAP16[ptr >> 1];")
+    public static native short getShort(int ptr);
+
+    @JSBody(params = {"ptr", "value"}, script = "Module.HEAP16[ptr >> 1] = value;")
+    public static native void setShort(int ptr, short value);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAP32[ptr >> 2];")
+    public static native int getInt(int ptr);
+
+    @JSBody(params = {"ptr", "value"}, script = "Module.HEAP32[ptr >> 2] = value;")
+    public static native void setInt(int ptr, int value);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAPF32[ptr >> 2];")
+    public static native float getFloat(int ptr);
+
+    @JSBody(params = {"ptr", "value"}, script = "Module.HEAPF32[ptr >> 2] = value;")
+    public static native void setFloat(int ptr, float value);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAPF64[ptr >> 3];")
+    public static native double getDouble(int ptr);
+
+    @JSBody(params = {"ptr", "value"}, script = "Module.HEAPF64[ptr >> 3] = value;")
+    public static native void setDouble(int ptr, double value);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAPU8[ptr];")
+    public static native int getUnsignedByte(int ptr);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAPU16[ptr >> 1];")
+    public static native int getUnsignedShort(int ptr);
+
+    @JSBody(params = {"ptr"}, script = "return Module.HEAPU32[ptr >> 2];")
+    public static native int getUnsignedInt(int ptr);
+
+    /**
+     * Read a null-terminated UTF-8 string from WASM memory.
+     * @param ptr WASM pointer to the string, or 0 for null
+     * @return Java String, or null if ptr is 0
+     */
+    @JSBody(params = {"ptr"}, script = "return ptr ? $rt_str(Module.UTF8ToString(ptr)) : null;")
+    public static native String readString(int ptr);
+
+    /**
+     * Read a float array from WASM memory.
+     * @param ptr WASM pointer to float data
+     * @param count number of float elements to read
+     * @return Java float array
+     */
+    @JSBody(params = {"ptr", "count"}, script =
+            "var result = $rt_createFloatArray(count);"
+          + "result.data.set(Module.HEAPF32.subarray(ptr >> 2, (ptr >> 2) + count));"
+          + "return result;")
+    public static native float[] readFloatArray(int ptr, int count);
+}

--- a/gdx-jnigen-runtime-teavm/src/main/resources/META-INF/services/org.teavm.vm.spi.TeaVMPlugin
+++ b/gdx-jnigen-runtime-teavm/src/main/resources/META-INF/services/org.teavm.vm.spi.TeaVMPlugin
@@ -1,0 +1,1 @@
+com.badlogic.gdx.jnigen.teavm.TeaVMJnigenPlugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,12 @@
 includeBuild("compiling")
 include ':gdx-jnigen-loader'
 include ':gdx-jnigen-runtime'
+include ':gdx-jnigen-runtime-gwt'
+include ':gdx-jnigen-runtime-teavm'
 include ':gdx-jnigen-generator-test'
 
 project(":gdx-jnigen-loader").name = "jnigen-loader"
 project(":gdx-jnigen-runtime").name = "jnigen-runtime"
+project(":gdx-jnigen-runtime-gwt").name = "jnigen-runtime-gwt"
+project(":gdx-jnigen-runtime-teavm").name = "jnigen-runtime-teavm"
 project(":gdx-jnigen-generator-test").name = "jnigen-generator-test"


### PR DESCRIPTION
The aim of this PR is to support Emscripten (WASM) build target to jnigen. Most of the info are in the README file. TeaVM support should be already fully working (gdx-miniaudio successfully compiles in any aspect). GWT is half implemented, it lacks of auto-generated bridge functions, which I don't know how much it worth to support.. TeaVM is just better for anything :D 

Because `JNIEnv` doesn't exists in emscripten, existing libraries that leverage on this to share objects between native and java should be replaced somehow, this how I did in miniaudio: https://github.com/rednblackgames/gdx-miniaudio/commit/4e2236069d7a3da8d7b354354446835109ad81da 

Needs testing and reviewing. Mostly because I had just the general idea, but most of the code is AI generated, and so must be properly reviewed.

At moment, this is the best I can do, thanks!