### PR TITLE
Allow customising of shared library loading behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,40 @@ Your artifacts will be published using `groupid:artifactid-platform:version:clas
 replace classifierXXX with the target name.
 
 e.g. natives-desktop, natives-ios, natives-android-arm64-v8a 
+
+## Customizing native library loading
+
+By default `SharedLibraryLoader` loads natives per platform: on iOS nothing is loaded (natives are loaded as frameworks),
+on Android the library is loaded by name with `System.loadLibrary`, and on the desktop the library is extracted from the natives jar and loaded from an absolute path.
+
+You can replace this behaviour on any platform by installing a `SharedLibraryLoadStrategy` before the first library is loaded. 
+The strategy receives the `SharedLibraryLoader` as a toolkit, exposing the loading primitives `loadSystemLibrary(name)` (load by name),
+`extractFile(sourcePath, dirName)` (reuse the already-extracted file or extract it from the jar with the full location fallback, returning the `File` without loading)
+and `loadFromAbsolutePath(path)` (load a file), so you can compose your own loading, including intercepting the actual load without reimplementing extraction.
+
+The default desktop behaviour is simply `loadFromAbsolutePath(extractFile(name, null).getAbsolutePath())`.
+
+Extend `DefaultSharedLibraryLoadStrategy` to customize a single platform and delegate the rest to `super`. For example, to load on Android through [ReLinker](https://github.com/KeepSafe/ReLinker):
+
+```java
+SharedLibraryLoader.setLoadStrategy(new DefaultSharedLibraryLoadStrategy() {
+    @Override
+    public void load(SharedLibraryLoader loader, String libraryName, String platformName) {
+        if (HostDetection.os == Os.Android)
+            ReLinker.loadLibrary(context, platformName);
+        else
+            super.load(loader, libraryName, platformName);
+    }
+});
+```
+
+Or load a library that is already on disk, bypassing jar extraction entirely:
+
+```java
+SharedLibraryLoader.setLoadStrategy(new SharedLibraryLoadStrategy() {
+    @Override
+    public void load(SharedLibraryLoader loader, String libraryName, String platformName) {
+        loader.loadFromAbsolutePath("/opt/natives/" + platformName);
+    }
+});
+```

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/DefaultSharedLibraryLoadStrategy.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/DefaultSharedLibraryLoadStrategy.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.jnigen.loader;
+
+import com.badlogic.gdx.jnigen.commons.HostDetection;
+
+import java.io.File;
+import java.io.IOException;
+
+/** Default {@link SharedLibraryLoadStrategy}: on iOS nothing is loaded, on Android the library is loaded by name via {@link System#loadLibrary(String)}, and on the desktop it
+ * is extracted from the natives jar and loaded from an absolute path. Extend this class and override {@link #load} to customise a
+ * single platform while delegating the rest to {@code super}. */
+public class DefaultSharedLibraryLoadStrategy implements SharedLibraryLoadStrategy {
+
+	@Override
+	public void load (SharedLibraryLoader loader, String libraryName, String platformName) {
+		switch (HostDetection.os) {
+		case IOS:
+			return;
+		case Android:
+			loader.loadSystemLibrary(platformName);
+			break;
+		default:
+			File extracted = loader.extractFile(platformName, null);
+			loader.loadFromAbsolutePath(extracted.getAbsolutePath());
+		}
+	}
+}

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoadStrategy.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoadStrategy.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.gdx.jnigen.loader;
+
+/** Strategy controlling how {@link SharedLibraryLoader} loads a native library on the current platform. Implementations may
+ * load a system library by name, extract it from the natives jar, load it from an absolute path, or do anything custom on any
+ * platform. Install one via {@link SharedLibraryLoader#setLoadStrategy(SharedLibraryLoadStrategy)} before the first library is
+ * loaded.
+ * <p>
+ * Override only what you need by extending {@link DefaultSharedLibraryLoadStrategy} and delegating the rest to {@code super}, for
+ * example to route Android loading through <a href="https://github.com/KeepSafe/ReLinker">ReLinker</a>. */
+public interface SharedLibraryLoadStrategy {
+
+	/** Loads the native library for the current platform.
+	 * @param loader the loader to use as a toolkit. Provides the loading primitives
+	 *           ({@link SharedLibraryLoader#loadSystemLibrary(String)}, {@link SharedLibraryLoader#extractFile(String, String)},
+	 *           {@link SharedLibraryLoader#loadFromAbsolutePath(String)}, {@link SharedLibraryLoader#mapLibraryName(String)}).
+	 * @param libraryName the platform independent name passed to {@link SharedLibraryLoader#load(String)}.
+	 * @param platformName the platform dependent name, i.e. the result of {@link SharedLibraryLoader#mapLibraryName(String)}. */
+	void load (SharedLibraryLoader loader, String libraryName, String platformName);
+}

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.gdx.jnigen.loader;
 
-import com.badlogic.gdx.jnigen.commons.Architecture;
 import com.badlogic.gdx.jnigen.commons.HostDetection;
 import com.badlogic.gdx.jnigen.commons.Os;
 
@@ -27,7 +26,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Random;
 import java.util.UUID;
@@ -215,17 +213,10 @@ public class SharedLibraryLoader {
 	}
 
 	private boolean canExecute (File file) {
-		try {
-			Method canExecute = File.class.getMethod("canExecute");
-			if ((Boolean)canExecute.invoke(file)) return true;
-
-			Method setExecutable = File.class.getMethod("setExecutable", boolean.class, boolean.class);
-			setExecutable.invoke(file, true, false);
-
-			return (Boolean)canExecute.invoke(file);
-		} catch (Exception ignored) {
-		}
-		return false;
+		if (file.canExecute())
+			return true;
+		file.setExecutable(true, false);
+		return file.canExecute();
 	}
 
 	private File extractFile (String sourcePath, String sourceCrc, File extractedFile) throws IOException {

--- a/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
+++ b/gdx-jnigen-loader/src/main/java/com/badlogic/gdx/jnigen/loader/SharedLibraryLoader.java
@@ -42,6 +42,14 @@ public class SharedLibraryLoader {
 	static private final HashSet<String> loadedLibraries = new HashSet<>();
 	static private final Random random = new Random();
 
+	static private SharedLibraryLoadStrategy loadStrategy = new DefaultSharedLibraryLoadStrategy();
+
+	/** Sets the strategy used to load native libraries, replacing the {@link DefaultSharedLibraryLoadStrategy}. This is process
+	 * global; install a custom strategy before the first library is loaded. */
+	static public synchronized void setLoadStrategy (SharedLibraryLoadStrategy strategy) {
+		loadStrategy = strategy;
+	}
+
 	private String nativesJar;
 
 	public SharedLibraryLoader () {
@@ -77,7 +85,7 @@ public class SharedLibraryLoader {
 
 	/** Maps a platform independent library name to a platform dependent name. */
 	public String mapLibraryName (String libraryName) {
-		if (HostDetection.os == Os.Android)
+		if (HostDetection.os == Os.Android || HostDetection.os == Os.IOS)
 			return libraryName;
 		return HostDetection.os.getLibPrefix() + libraryName + HostDetection.architecture.toSuffix() + HostDetection.bitness.toSuffix() + "." + HostDetection.os.getLibExtension();
 	}
@@ -85,17 +93,11 @@ public class SharedLibraryLoader {
 	/** Loads a shared library for the platform the application is running on.
 	 * @param libraryName The platform independent library name. If not contain a prefix (eg lib) or suffix (eg .dll). */
 	public void load (String libraryName) {
-		// in case of iOS, it's unnecessary to dlopen
-		if (HostDetection.os == Os.IOS) return;
-
 		synchronized (SharedLibraryLoader.class) {
 			if (isLoaded(libraryName)) return;
 			String platformName = mapLibraryName(libraryName);
 			try {
-				if (HostDetection.os == Os.Android)
-					System.loadLibrary(platformName);
-				else
-					loadFile(platformName);
+				loadStrategy.load(this, libraryName, platformName);
 				setLoaded(libraryName);
 			} catch (Throwable ex) {
 				throw new SharedLibraryLoadRuntimeException("Couldn't load shared library '" + platformName + "' for target: "
@@ -103,6 +105,11 @@ public class SharedLibraryLoader {
 						ex);
 			}
 		}
+	}
+
+	/** Loads a system library by its platform dependent name via {@link System#loadLibrary(String)}. */
+	public void loadSystemLibrary (String platformName) {
+		System.loadLibrary(platformName);
 	}
 
 	private InputStream readFile (String path) {
@@ -128,7 +135,7 @@ public class SharedLibraryLoader {
 	 * @param sourcePath The file to extract from the classpath or JAR.
 	 * @param dirName The name of the subdirectory where the file will be extracted. If null, the file's CRC will be used.
 	 * @return The extracted file. */
-	public File extractFile (String sourcePath, String dirName) throws IOException {
+	public File extractFile (String sourcePath, String dirName) {
 		try {
 			String sourceCrc = crc(readFile(sourcePath));
 			if (dirName == null) dirName = sourceCrc;
@@ -152,7 +159,7 @@ public class SharedLibraryLoader {
 	 * extraction fails and the file exists at java.library.path, that file is returned.
 	 * @param sourcePath The file to extract from the classpath or JAR.
 	 * @param dir The location where the extracted file will be written. */
-	public void extractFileTo (String sourcePath, File dir) throws IOException {
+	public void extractFileTo (String sourcePath, File dir) {
 		extractFile(sourcePath, crc(readFile(sourcePath)), new File(dir, new File(sourcePath).getName()));
 	}
 
@@ -219,7 +226,7 @@ public class SharedLibraryLoader {
 		return file.canExecute();
 	}
 
-	private File extractFile (String sourcePath, String sourceCrc, File extractedFile) throws IOException {
+	private File extractFile (String sourcePath, String sourceCrc, File extractedFile) {
 		String extractedCrc = null;
 		if (extractedFile.exists()) {
 			try {
@@ -254,55 +261,9 @@ public class SharedLibraryLoader {
 		return extractedFile;
 	}
 
-	/** Extracts the source file and calls System.load. Attemps to extract and load from multiple locations. Throws runtime
-	 * exception if all fail. */
-	private void loadFile (String sourcePath) {
-		String sourceCrc = crc(readFile(sourcePath));
-
-		String fileName = new File(sourcePath).getName();
-
-		// Temp directory with username in path.
-		File file = new File(System.getProperty("java.io.tmpdir") + "/libgdx" + System.getProperty("user.name") + "/" + sourceCrc,
-			fileName);
-		Throwable ex = loadFile(sourcePath, sourceCrc, file);
-		if (ex == null) return;
-
-		// System provided temp directory.
-		try {
-			file = File.createTempFile(sourceCrc, null);
-			if (file.delete() && loadFile(sourcePath, sourceCrc, file) == null) return;
-		} catch (Throwable ignored) {
-		}
-
-		// User home.
-		file = new File(System.getProperty("user.home") + "/.libgdx/" + sourceCrc, fileName);
-		if (loadFile(sourcePath, sourceCrc, file) == null) return;
-
-		// Relative directory.
-		file = new File(".temp/" + sourceCrc, fileName);
-		if (loadFile(sourcePath, sourceCrc, file) == null) return;
-
-		// Fallback to java.library.path location, eg for applets.
-		file = new File(System.getProperty("java.library.path"), sourcePath);
-		if (file.exists()) {
-			loadFromAbsolutePath(file.getAbsolutePath());
-			return;
-		}
-
-		throw new SharedLibraryLoadRuntimeException(ex);
-	}
-
-	/** @return null if the file was extracted and loaded. */
-	private Throwable loadFile (String sourcePath, String sourceCrc, File extractedFile) {
-		try {
-			loadFromAbsolutePath(extractFile(sourcePath, sourceCrc, extractedFile).getAbsolutePath());
-			return null;
-		} catch (Throwable ex) {
-			return ex;
-		}
-	}
-
-	private void loadFromAbsolutePath(String path) {
+	/** Loads a native library from an absolute file path via {@link System#load(String)}. Lets a strategy load a library that is
+	 * already on disk. */
+	public void loadFromAbsolutePath(String path) {
 		System.load(path);
 	}
 


### PR DESCRIPTION
Generalised implementation of https://github.com/libgdx/gdx-jnigen/pull/78.

Exposes `SharedLibraryLoadStrategy` which users can set, to intercept `load` call. Exposes `SharedLibraryLoader` so that the usual utils used by it (like extracting) can still be used.