### PR TITLE
Add missing CHandler import

### DIFF
--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/GlobalType.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/types/GlobalType.java
@@ -49,6 +49,7 @@ public class GlobalType implements MappedType {
     }
 
     public void write(CompilationUnit cuPublic, ClassOrInterfaceDeclaration global, CompilationUnit cuInternal, ClassOrInterfaceDeclaration globalInternal, HashMap<MethodDeclaration, String> patchNativeMethods) {
+        cuPublic.addImport(ClassNameConstants.CHANDLER_CLASS);
         cuPublic.addImport(ClassNameConstants.CXXEXCEPTION_CLASS);
         cuPublic.addImport(IllegalArgumentException.class);
         global.addStaticInitializer()


### PR DESCRIPTION
When running the jnigenGenerateBindings task the CHandler import is missing and has to be added manually.