### PR TITLE
Add constructor to UShortPointer to match other Pointer classes

### DIFF
--- a/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/integer/UShortPointer.java
+++ b/gdx-jnigen-runtime/src/main/java/com/badlogic/gdx/jnigen/runtime/pointer/integer/UShortPointer.java
@@ -26,6 +26,10 @@ public class UShortPointer extends VoidPointer {
         super(count * BYTE_SIZE);
     }
 
+    public UShortPointer(long pointer, boolean freeOnGC) {
+        super(pointer, freeOnGC);
+    }
+
     public UShortPointer(long pointer, boolean freeOnGC, int capacity) {
         super(pointer, freeOnGC, capacity * BYTE_SIZE);
     }


### PR DESCRIPTION
UShortPointer doesn't have a `(long pointer, boolean freeOnGC)` constructor like other `***Pointer` classes
And jnigen-generator expects UShortPointer to have a `(long pointer, boolean freeOnGC)` constructor