### PR TITLE
Prepend _ for argument names that can collide with reserved argument names

### DIFF
--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
@@ -303,18 +303,7 @@ public class Generator {
                 CXCursor paramCursor = clang_Cursor_getArgument(cursor, i);
                 String potentialName = clang_getCursorSpelling(paramCursor).getString();
                 if (!potentialName.isEmpty()) {
-                    name = potentialName;
-                    switch (name) {
-                        case "env":
-                            name = "_env";
-                            break;
-                        case "clazz":
-                            name = "_clazz";
-                            break;
-                        case "object":
-                            name = "_object";
-                            break;
-                    }
+                    name = JavaUtils.deduplicateArgumentName(potentialName);
                 }
             }
             TypeDefinition argTypeDefinition = registerCXType(argType, name, null);

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
@@ -302,8 +302,20 @@ public class Generator {
             if (cursor != null) {
                 CXCursor paramCursor = clang_Cursor_getArgument(cursor, i);
                 String potentialName = clang_getCursorSpelling(paramCursor).getString();
-                if (!potentialName.isEmpty())
+                if (!potentialName.isEmpty()) {
                     name = potentialName;
+                    switch (name) {
+                        case "env":
+                            name = "_env";
+                            break;
+                        case "clazz":
+                            name = "_clazz";
+                            break;
+                        case "object":
+                            name = "_object";
+                            break;
+                    }
+                }
             }
             TypeDefinition argTypeDefinition = registerCXType(argType, name, null);
 

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/JavaUtils.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/JavaUtils.java
@@ -41,6 +41,18 @@ public class JavaUtils {
         return cName;
     }
 
+    public static String deduplicateArgumentName(String cName) {
+        switch (cName) {
+            case "env":
+                return "_env";
+            case "clazz":
+                return "_clazz";
+            case "object":
+                return "_object";
+        }
+        return cName;
+    }
+
     public static Expression getOffsetAsExpression(int index, OffsetCalculator calculator) {
         return getSizeAsExpression((target) -> calculator.getOffset(index, target));
     }


### PR DESCRIPTION
If a function signature in a header contains an argument with the name env, clazz or object it will collide with JNIEnv *env or clazz/object