### PR TITLE
Properly close visitors on parse fail and check if they got properly allocated

### DIFF
--- a/compiling/gdx-jnigen-generator/build.gradle
+++ b/compiling/gdx-jnigen-generator/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testRuntimeOnly 'org.bytedeco:llvm-platform:19.1.3-1.5.11'
 }
 
 test {

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/ClangUtils.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/ClangUtils.java
@@ -1,13 +1,51 @@
 package com.badlogic.gdx.jnigen.generator;
 
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.PointerPointer;
+import org.bytedeco.llvm.clang.CXClientData;
+import org.bytedeco.llvm.clang.CXCursor;
+import org.bytedeco.llvm.clang.CXCursorVisitor;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 
+import static org.bytedeco.llvm.global.clang.clang_visitChildren;
+
 public class ClangUtils {
     private static final File NULL_FILE = new File(System.getProperty("os.name").startsWith("Windows") ? "NUL" : "/dev/null");
+
+
+    public static void checkVisitorAllocated(CXCursorVisitor visitor) {
+        boolean allocated = false;
+        if (visitor != null && !visitor.isNull()) {
+            Pointer function = new PointerPointer<>(visitor).get(0);
+            allocated = function != null && !function.isNull();
+        }
+        if (!allocated)
+            throw new IllegalStateException("CXCursorVisitor got no JavaCPP callback slot (at most 10 per class). "
+                    + "Either a visitor was not closed (missing try/finally) or visits are nested too deep.");
+    }
+
+    @FunctionalInterface
+    public interface CursorCallback {
+        int call(CXCursor current, CXCursor parent);
+    }
+
+    public static int visitChildren(CXCursor cursor, CursorCallback callback) {
+
+        try (CXCursorVisitor visitor = new CXCursorVisitor() {
+            @Override
+            public int call(CXCursor current, CXCursor parent, CXClientData clientData) {
+                return callback.call(current, parent);
+            }
+        }) {
+            checkVisitorAllocated(visitor);
+            return clang_visitChildren(cursor, visitor, null);
+        }
+    }
 
     public static String[] getIncludePaths() {
         try {

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/Generator.java
@@ -7,10 +7,7 @@ import com.badlogic.gdx.jnigen.generator.types.*;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.PointerPointer;
-import org.bytedeco.javacpp.annotation.ByVal;
-import org.bytedeco.llvm.clang.CXClientData;
 import org.bytedeco.llvm.clang.CXCursor;
-import org.bytedeco.llvm.clang.CXCursorVisitor;
 import org.bytedeco.llvm.clang.CXIndex;
 import org.bytedeco.llvm.clang.CXSourceLocation;
 import org.bytedeco.llvm.clang.CXSourceRange;
@@ -243,24 +240,18 @@ public class Generator {
     // Clangs typesystem doesn't retain arg names, so we need to reparse them for closures
     public static void patchSignatureArgNamesWithVisitor(FunctionSignature functionSignature, CXCursor cursor) {
         AtomicInteger counter = new AtomicInteger(0);
-        CXCursorVisitor parameterVisitor = new CXCursorVisitor() {
-            @Override
-            public int call(CXCursor current, CXCursor parent, CXClientData client_data) {
-                if (current.kind() == CXCursor_ParmDecl) {
-                    int id = counter.getAndIncrement();
+        ClangUtils.visitChildren(cursor, (current, parent) -> {
+            if (current.kind() == CXCursor_ParmDecl) {
+                int id = counter.getAndIncrement();
 
-                    String name = clang_getCursorSpelling(current).getString();
-                    if (name.isEmpty())
-                        name = "arg" + id;
+                String name = clang_getCursorSpelling(current).getString();
+                if (name.isEmpty())
+                    name = "arg" + id;
 
-                    functionSignature.getArguments()[id].setName(name);
-                }
-                return CXChildVisit_Recurse;
+                functionSignature.getArguments()[id].setName(name);
             }
-        };
-
-        clang_visitChildren(cursor, parameterVisitor, null);
-        parameterVisitor.close();
+            return CXChildVisit_Recurse;
+        });
     }
 
     public static void dumpAST(CXCursor cursor, int depth) {
@@ -271,17 +262,10 @@ public class Generator {
                 clang_getTypeSpelling(clang_getCursorType(cursor)).getString(),
                 clang_getCursorKind(cursor));
 
-        CXCursorVisitor visitor = new CXCursorVisitor() {
-            @Override
-            public int call(CXCursor cursor, CXCursor parent, CXClientData client_data) {
-                dumpAST(cursor, depth + 1);
-                return CXChildVisit_Continue;
-            }
-        };
-
-        clang_visitChildren(cursor, visitor, null);
-
-        visitor.close();
+        ClangUtils.visitChildren(cursor, (child, parent) -> {
+            dumpAST(child, depth + 1);
+            return CXChildVisit_Continue;
+        });
     }
 
     public static FunctionSignature parseFunctionSignature(String functionName, CXType functionType, CXCursor cursor) {
@@ -327,9 +311,8 @@ public class Generator {
         CXTranslationUnit translationUnit = clang_parseTranslationUnit(index, file, argPointer, parameter.length, null, 0,
                 CXTranslationUnit_SkipFunctionBodies | CXTranslationUnit_DetailedPreprocessingRecord | CXTranslationUnit_IncludeAttributedTypes);
 
-        CXCursorVisitor visitor = new CXCursorVisitor() {
-            @Override
-            public int call(@ByVal CXCursor current, @ByVal CXCursor parent, CXClientData cxClientData) {
+        try {
+            ClangUtils.visitChildren(clang_getTranslationUnitCursor(translationUnit), (current, parent) -> {
                 CXSourceLocation location = clang_getCursorLocation(current);
                 if (clang_Location_isInSystemHeader(location) != 0)
                     return CXChildVisit_Continue;
@@ -365,14 +348,13 @@ public class Generator {
                 }
 
                 return CXChildVisit_Recurse;
-            }
-        };
-
-        clang_visitChildren(clang_getTranslationUnitCursor(translationUnit), visitor, null);
-        argPointer.close();
-        file.close();
-        clang_disposeTranslationUnit(translationUnit);
-        clang_disposeIndex(index);
+            });
+        } finally {
+            argPointer.close();
+            file.close();
+            clang_disposeTranslationUnit(translationUnit);
+            clang_disposeIndex(index);
+        }
     }
 
     public static void generateJavaCode(String path) {

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/parser/EnumParser.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/parser/EnumParser.java
@@ -1,14 +1,13 @@
 package com.badlogic.gdx.jnigen.generator.parser;
 
+import com.badlogic.gdx.jnigen.generator.ClangUtils;
 import com.badlogic.gdx.jnigen.generator.JavaUtils;
 import com.badlogic.gdx.jnigen.generator.Manager;
 import com.badlogic.gdx.jnigen.generator.types.EnumConstant;
 import com.badlogic.gdx.jnigen.generator.types.EnumType;
 import com.badlogic.gdx.jnigen.generator.types.MappedType;
 import com.badlogic.gdx.jnigen.generator.types.TypeDefinition;
-import org.bytedeco.llvm.clang.CXClientData;
 import org.bytedeco.llvm.clang.CXCursor;
-import org.bytedeco.llvm.clang.CXCursorVisitor;
 import org.bytedeco.llvm.clang.CXType;
 
 import static org.bytedeco.llvm.global.clang.*;
@@ -41,23 +40,17 @@ public class EnumParser {
         if (commentParser.isPresent())
             enumType.setComment(commentParser.parse());
 
-        CXCursorVisitor visitor = new CXCursorVisitor() {
-            @Override
-            public int call(CXCursor current, CXCursor parent, CXClientData cxClientData) {
-                String cursorSpelling = clang_getCursorSpelling(current).getString();
-                if (current.kind() == CXCursor_EnumConstantDecl) {
-                    long constantValue = clang_getEnumConstantDeclValue(current);
-                    if (constantValue > Integer.MAX_VALUE || constantValue < Integer.MIN_VALUE)
-                        throw new IllegalArgumentException("Why is the enum " + enumType.abstractType() + " so biiig? Please open a issue in the gdx-jnigen repo");
-                    EnumConstant constant = new EnumConstant((int) constantValue, cursorSpelling, new CommentParser(current).parse());
-                    enumType.registerConstant(constant);
-                }
-                return CXChildVisit_Recurse;
+        ClangUtils.visitChildren(cursor, (current, parent) -> {
+            String cursorSpelling = clang_getCursorSpelling(current).getString();
+            if (current.kind() == CXCursor_EnumConstantDecl) {
+                long constantValue = clang_getEnumConstantDeclValue(current);
+                if (constantValue > Integer.MAX_VALUE || constantValue < Integer.MIN_VALUE)
+                    throw new IllegalArgumentException("Why is the enum " + enumType.abstractType() + " so biiig? Please open a issue in the gdx-jnigen repo");
+                EnumConstant constant = new EnumConstant((int) constantValue, cursorSpelling, new CommentParser(current).parse());
+                enumType.registerConstant(constant);
             }
-        };
-
-        clang_visitChildren(cursor, visitor, null);
-        visitor.close();
+            return CXChildVisit_Recurse;
+        });
 
         Manager.getInstance().addEnum(enumType);
 

--- a/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/parser/StackElementParser.java
+++ b/compiling/gdx-jnigen-generator/src/main/java/com/badlogic/gdx/jnigen/generator/parser/StackElementParser.java
@@ -1,12 +1,11 @@
 package com.badlogic.gdx.jnigen.generator.parser;
 
+import com.badlogic.gdx.jnigen.generator.ClangUtils;
 import com.badlogic.gdx.jnigen.generator.Generator;
 import com.badlogic.gdx.jnigen.generator.JavaUtils;
 import com.badlogic.gdx.jnigen.generator.Manager;
 import com.badlogic.gdx.jnigen.generator.types.*;
-import org.bytedeco.llvm.clang.CXClientData;
 import org.bytedeco.llvm.clang.CXCursor;
-import org.bytedeco.llvm.clang.CXCursorVisitor;
 import org.bytedeco.llvm.clang.CXType;
 
 import static org.bytedeco.llvm.global.clang.*;
@@ -18,6 +17,7 @@ public class StackElementParser {
     private final String alternativeName;
     private final StackElementType stackElementType;
     private MappedType parent;
+    private CXType anonymousType;
 
     public StackElementParser(TypeDefinition typeDefinition, CXType toParse, String alternativeName, MappedType parent) {
         this.typeDefinition = typeDefinition;
@@ -57,73 +57,63 @@ public class StackElementParser {
         if (commentParser.isPresent()) {
             stackElementType.setComment(commentParser.parse());
         }
-        CXCursorVisitor visitor = new CXCursorVisitor() {
-            private CXType anonymousType;
+        ClangUtils.visitChildren(cursor, this::visitField);
+        // Flush a trailing anonymous struct/union that no named field referenced.
+        if (anonymousType != null)
+            parseAnonymousType();
+    }
 
-            private void parseAnonymousType() {
-                CXCursor anonymousCursor = clang_getTypeDeclaration(anonymousType);
+    private void parseAnonymousType() {
+        CXCursor anonymousCursor = clang_getTypeDeclaration(anonymousType);
+        anonymousType = null;
+        ClangUtils.visitChildren(anonymousCursor, this::visitField);
+        if (anonymousType != null)
+            parseAnonymousType();
+    }
+
+    private int visitField(CXCursor current, CXCursor parent) {
+        String cursorSpelling = clang_getCursorSpelling(current).getString();
+        if (current.kind() == CXCursor_FieldDecl) {
+            CXType type = clang_getCursorType(current);
+
+            if (anonymousType != null) {
+                CXType resolvedType = type;
+                if (resolvedType.kind() == CXType_ConstantArray)
+                    resolvedType = clang_getArrayElementType(resolvedType);
+
+                resolvedType = clang_getCursorType(clang_getTypeDeclaration(resolvedType));
+
+                if (clang_equalTypes(resolvedType, anonymousType) == 0)
+                    parseAnonymousType();
+
                 anonymousType = null;
-                clang_visitChildren(anonymousCursor, this, null);
-                if (anonymousType != null)
-                    parseAnonymousType();
             }
 
-            @Override
-            public void close() {
-                if (anonymousType != null)
-                    parseAnonymousType();
-                super.close();
+            TypeDefinition fieldDefinition = Generator.registerCXType(type, cursorSpelling, stackElementType);
+            if (fieldDefinition.getTypeKind() == TypeKind.VOID)
+                stackElementType.markIncomplete();
+
+            if (fieldDefinition.getTypeKind() == TypeKind.CLOSURE) {
+                Generator.patchClosureTypeWithCursor(fieldDefinition, current);
             }
 
-            @Override
-            public int call(CXCursor current, CXCursor parent, CXClientData cxClientData) {
-                String cursorSpelling = clang_getCursorSpelling(current).getString();
-                if (current.kind() == CXCursor_FieldDecl) {
-                    CXType type = clang_getCursorType(current);
+            NamedType namedType = new NamedType(fieldDefinition, cursorSpelling);
+            StackElementField field = new StackElementField(namedType, new CommentParser(current).parse());
+            stackElementType.addField(field);
 
-                    if (anonymousType != null) {
-                        CXType resolvedType = type;
-                        if (resolvedType.kind() == CXType_ConstantArray)
-                            resolvedType = clang_getArrayElementType(resolvedType);
+            while (fieldDefinition.getNestedDefinition() != null)
+                fieldDefinition = fieldDefinition.getNestedDefinition();
 
-                        resolvedType = clang_getCursorType(clang_getTypeDeclaration(resolvedType));
+            if (fieldDefinition.isAnonymous())
+                stackElementType.addChild(fieldDefinition);
+        } else if (current.kind() == CXCursor_StructDecl || current.kind() == CXCursor_UnionDecl) {
+            if (anonymousType != null)
+                parseAnonymousType();
 
-                        if (clang_equalTypes(resolvedType, anonymousType) == 0)
-                            parseAnonymousType();
+            if (clang_Cursor_isAnonymous(current) != 0)
+                anonymousType = clang_getCursorType(current);
+        }
 
-                        anonymousType = null;
-                    }
-
-                    TypeDefinition fieldDefinition = Generator.registerCXType(type, cursorSpelling, stackElementType);
-                    if (fieldDefinition.getTypeKind() == TypeKind.VOID)
-                        stackElementType.markIncomplete();
-
-                    if (fieldDefinition.getTypeKind() == TypeKind.CLOSURE) {
-                        Generator.patchClosureTypeWithCursor(fieldDefinition, current);
-                    }
-
-                    NamedType namedType = new NamedType(fieldDefinition, cursorSpelling);
-                    StackElementField field = new StackElementField(namedType, new CommentParser(current).parse());
-                    stackElementType.addField(field);
-
-                    while (fieldDefinition.getNestedDefinition() != null)
-                        fieldDefinition = fieldDefinition.getNestedDefinition();
-
-                    if (fieldDefinition.isAnonymous())
-                        stackElementType.addChild(fieldDefinition);
-                } else if (current.kind() == CXCursor_StructDecl || current.kind() == CXCursor_UnionDecl) {
-                    if (anonymousType != null)
-                        parseAnonymousType();
-
-                    if (clang_Cursor_isAnonymous(current) != 0)
-                        anonymousType = clang_getCursorType(current);
-                }
-
-                return CXChildVisit_Continue;
-            }
-        };
-
-        clang_visitChildren(cursor, visitor, null);
-        visitor.close();
+        return CXChildVisit_Continue;
     }
 }

--- a/compiling/gdx-jnigen-generator/src/test/java/com/badlogic/gdx/jnigen/generator/CursorVisitorSlotTest.java
+++ b/compiling/gdx-jnigen-generator/src/test/java/com/badlogic/gdx/jnigen/generator/CursorVisitorSlotTest.java
@@ -1,0 +1,117 @@
+package com.badlogic.gdx.jnigen.generator;
+
+import org.bytedeco.llvm.clang.CXClientData;
+import org.bytedeco.llvm.clang.CXCursor;
+import org.bytedeco.llvm.clang.CXCursorVisitor;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.bytedeco.llvm.global.clang.CXChildVisit_Continue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * JavaCPP hands out at most 10 callback slots per FunctionPointer class. An 11th live
+ * {@link CXCursorVisitor} silently gets a NULL native function pointer, and the next
+ * clang_visitChildren jumps to 0x0 (SIGSEGV). These tests lock in the loud failure
+ * ({@link ClangUtils#checkVisitorAllocated}) and that the generator never leaks visitor slots,
+ * even when a parse fails half-way through a nested visit.
+ */
+public class CursorVisitorSlotTest {
+
+    /** Mirrors JavaCPP's {@code @Allocator(max)} default. */
+    private static final int JAVACPP_CALLBACK_SLOTS = 10;
+
+    private static CXCursorVisitor newVisitor() {
+        return new CXCursorVisitor() {
+            @Override
+            public int call(CXCursor current, CXCursor parent, CXClientData clientData) {
+                return CXChildVisit_Continue;
+            }
+        };
+    }
+
+    @Test
+    void allocatedVisitorPasses() {
+        CXCursorVisitor visitor = newVisitor();
+        try {
+            assertDoesNotThrow(() -> ClangUtils.checkVisitorAllocated(visitor));
+        } finally {
+            visitor.close();
+        }
+    }
+
+    @Test
+    void unallocatedVisitorIsDetected() {
+        CXCursorVisitor[] hoarded = new CXCursorVisitor[JAVACPP_CALLBACK_SLOTS];
+        CXCursorVisitor eleventh = null;
+        CXCursorVisitor afterRelease = null;
+        try {
+            for (int i = 0; i < hoarded.length; i++)
+                hoarded[i] = newVisitor();
+            for (CXCursorVisitor visitor : hoarded)
+                ClangUtils.checkVisitorAllocated(visitor);
+
+            eleventh = newVisitor();
+            CXCursorVisitor unallocated = eleventh;
+            assertThrows(IllegalStateException.class, () -> ClangUtils.checkVisitorAllocated(unallocated));
+
+            // Closing a visitor frees its slot for the next allocation.
+            hoarded[0].close();
+            hoarded[0] = null;
+            afterRelease = newVisitor();
+            CXCursorVisitor reallocated = afterRelease;
+            assertDoesNotThrow(() -> ClangUtils.checkVisitorAllocated(reallocated));
+        } finally {
+            for (CXCursorVisitor visitor : hoarded)
+                if (visitor != null)
+                    visitor.close();
+            if (eleventh != null)
+                eleventh.close();
+            if (afterRelease != null)
+                afterRelease.close();
+        }
+    }
+
+    /**
+     * A struct field with a variadic function-pointer type makes the generator throw from inside the
+     * StackElementParser visitor callback, which Generator.parse reports as "Failed to parse function"
+     * and carries on. Before try/finally closing, every such parse leaked the translation-unit visitor
+     * and the struct visitor; more runs than there are slots would then hand out a dead visitor.
+     */
+    @Test
+    void visitorsAreReleasedOnParseFailure() throws IOException {
+        assumeTrue(clangAvailable(), "clang not on PATH; Generator.parse needs it for include paths");
+
+        Path header = Files.createTempFile("visitor-slot", ".h");
+        Files.write(header, ("typedef struct Holder { int (*fn)(int, ...); } Holder;\n"
+                + "void use(Holder h);\n").getBytes());
+        try {
+            for (int run = 0; run < JAVACPP_CALLBACK_SLOTS + 2; run++) {
+                Manager.init(header.toString(), "com.example");
+                Generator.parse(header.toString(), new String[0]);
+            }
+        } finally {
+            Files.deleteIfExists(header);
+        }
+
+        CXCursorVisitor visitor = newVisitor();
+        try {
+            assertDoesNotThrow(() -> ClangUtils.checkVisitorAllocated(visitor));
+        } finally {
+            visitor.close();
+        }
+    }
+
+    private static boolean clangAvailable() {
+        try {
+            return new ProcessBuilder("clang", "--version").redirectErrorStream(true).start().waitFor() == 0;
+        } catch (IOException | InterruptedException e) {
+            return false;
+        }
+    }
+}

--- a/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/TestData.java
+++ b/gdx-jnigen-generator-test/src/main/java/com/badlogic/jnigen/generated/TestData.java
@@ -1,5 +1,6 @@
 package com.badlogic.jnigen.generated;
 
+import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.gdx.jnigen.runtime.c.CXXException;
 import com.badlogic.jnigen.generated.structs.GlobalArg;
 import com.badlogic.jnigen.generated.structs.forwardDeclStruct;
@@ -18,7 +19,6 @@ import com.badlogic.jnigen.generated.structs.FILE;
 import com.badlogic.jnigen.generated.structs.timespec;
 import com.badlogic.jnigen.generated.structs.TimeHolder;
 import com.badlogic.gdx.jnigen.runtime.closure.ClosureObject;
-import com.badlogic.gdx.jnigen.runtime.CHandler;
 import com.badlogic.jnigen.generated.TestData;
 import com.badlogic.jnigen.generated.TestData_Internal;
 import com.badlogic.jnigen.generated.enums.public_color;


### PR DESCRIPTION
javacpp only allows 10 active CXCursorVisitors: https://github.com/bytedeco/javacpp/issues/611
This fix ensures that no visitor is leaked and it checks if a visitor allocation failed.
